### PR TITLE
execute goreleaser --snapshot on every commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,24 @@ jobs:
       # Add files to Github release
       - run: github-release upload --user cloudradar-monitoring --repo frontman --tag ${CIRCLE_TAG} --name "frontman_${CIRCLE_TAG}_Windows_386.msi" --file "/go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_386.msi"
       - run: github-release upload --user cloudradar-monitoring --repo frontman --tag ${CIRCLE_TAG} --name "frontman_${CIRCLE_TAG}_Windows_x68_64.msi" --file "/go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_64.msi"
+  
+  goreleasse-test:
+    docker:
+      - image: cloudradario/go-build:0.0.5
+    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    steps:
+      - checkout
+      - run: goreleaser --snapshot
 
 workflows:
   version: 2
   test-on-commit:
     jobs:
       - test:
+          filters:
+            tags:
+              ignore: /.*/
+      - goreleasse-test:
           filters:
             tags:
               ignore: /.*/


### PR DESCRIPTION
To be sure that build works on all platforms we run `goreleaser --snapshot` on every commit