### PR TITLE
Mark as pre-realease when a rc tag is present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ jobs:
       - checkout
       # Build binaries
       - run: goreleaser --rm-dist
+      # Since goreleaser can't handle pre-releases as we need it we mark it later as pre-release using github-release
+      - run:
+          shell: /bin/bash
+          command: |
+           if [[ ${CIRCLE_TAG} =~ -{1}((0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$ ]] ; then github-release edit --user cloudradar-monitoring --repo frontman --tag ${CIRCLE_TAG} -p; fi
       # Create remote build dir
       - run: ssh -i /tmp/id_win_ssh -oStrictHostKeyChecking=no hero@13.80.137.211 mkdir -p /cygdrive/c/Users/hero/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist
       # Copy exe files to Windows VM for bundingling and signing

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: cloudradario/go-build:0.0.5
+      - image: cloudradario/go-build:0.0.6
     working_directory: /go/src/github.com/cloudradar-monitoring/frontman
     steps:
       - checkout
@@ -11,7 +11,7 @@ jobs:
   
   gorelease:
     docker:
-      - image: cloudradario/go-build:0.0.5
+      - image: cloudradario/go-build:0.0.6
     working_directory: /go/src/github.com/cloudradar-monitoring/frontman
     steps:
       # Setup our ssh key from env var to be able to connect to Windows VM
@@ -49,7 +49,7 @@ jobs:
   
   goreleasse-test:
     docker:
-      - image: cloudradario/go-build:0.0.5
+      - image: cloudradario/go-build:0.0.6
     working_directory: /go/src/github.com/cloudradar-monitoring/frontman
     steps:
       - checkout


### PR DESCRIPTION
Mark the release as pre-release when a tag like `1.0.0-rc1` is used.