### PR TITLE
set default log level to error and warn user if invalid log level is set

### DIFF
--- a/config.go
+++ b/config.go
@@ -64,8 +64,8 @@ type Frontman struct {
 
 	offlineResultsBuffer []Result
 
-	rootCAs              *x509.CertPool
-	version              string
+	rootCAs *x509.CertPool
+	version string
 }
 
 func New() *Frontman {
@@ -133,7 +133,6 @@ func New() *Frontman {
 		fm.HubPassword = os.Getenv("FRONTMAN_HUB_PASSWORD")
 	}
 
-	fm.SetLogLevel(LogLevelInfo)
 	return fm
 }
 


### PR DESCRIPTION
Set the default log level to error and print a warning if the user provided an invalid value for the loglevel