### PR TITLE
remove additional call to fm.SetLogLevel

### DIFF
--- a/config.go
+++ b/config.go
@@ -188,13 +188,11 @@ func (fm *Frontman) ReadConfigFromFile(configFilePath string, createIfNotExists 
 			fm.HubProxy = "http://" + fm.HubProxy
 		}
 		_, err := url.Parse(fm.HubProxy)
-
 		if err != nil {
 			return fmt.Errorf("Failed to parse 'hub_proxy' URL")
 		}
 	}
 
-	fm.SetLogLevel(fm.LogLevel)
 	if fm.LogFile != "" {
 		err := addLogFileHook(fm.LogFile, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 		if err != nil {

--- a/log.go
+++ b/log.go
@@ -78,7 +78,7 @@ func (hook *logrusFileHook) Levels() []log.Level {
 	}
 }
 
-// Sets Log level and corresponding logrus level
+// SetLogLevel sets Log level and corresponding logrus level
 func (fm *Frontman) SetLogLevel(lvl LogLevel) {
 	fm.LogLevel = lvl
 	log.SetLevel(lvl.LogrusLevel())


### PR DESCRIPTION
Using `-v` flag hat no effect. Log level was always set to error because of this additional call to `SetLogLevel`