### PR TITLE
Refactor handler.go

### DIFF
--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -346,7 +346,13 @@ sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"`
 	}
 
 	if *oneRunOnlyModePtr == true {
-		err := fm.RunOnce(inputFilePtr, output, interruptChan, false)
+		input, err := fm.FetchInput(inputFilePtr)
+		if err != nil {
+			log.Error(err)
+			return
+		}
+
+		err = fm.RunOnce(input, output, interruptChan, false)
 		if err != nil {
 			log.Error(err)
 		}

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -346,7 +346,10 @@ sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"`
 	}
 
 	if *oneRunOnlyModePtr == true {
-		fm.RunOnce(inputFilePtr, output, interruptChan, false)
+		err := fm.RunOnce(inputFilePtr, output, interruptChan, false)
+		if err != nil {
+			log.Error(err)
+		}
 		return
 	} else {
 		go func() {

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -355,6 +355,7 @@ sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"`
 		err = fm.RunOnce(input, output, interruptChan, false)
 		if err != nil {
 			log.Error(err)
+			return
 		}
 		return
 	} else {

--- a/handler.go
+++ b/handler.go
@@ -283,9 +283,12 @@ func (fm *Frontman) RunOnce(inputFilePath *string, outputFile *os.File, interrup
 	var err error
 
 	if inputFilePath == nil || *inputFilePath == "" {
+		// input file is not specified
+		// lets try to request the HUB
 		input, err = fm.InputFromHub()
 		if err != nil {
 			if fm.HubUser != "" {
+				// include Basic Auth login for the context if available
 				return fmt.Errorf("InputFromHub(%s:***): %s", fm.HubUser, err.Error())
 			}
 			

--- a/handler.go
+++ b/handler.go
@@ -239,8 +239,10 @@ func (fm *Frontman) sendResultsChanToHub(resultsChan chan Result) error {
 }
 
 func (fm *Frontman) sendResultsChanToHubWithInterval(resultsChan chan Result) error {
+	sendResultsTicker := time.NewTicker(secToDuration(fm.SenderModeInterval))
+	defer sendResultsTicker.Stop()
+
 	var results []Result
-	sendResultsTicker := time.Tick(secToDuration(fm.SenderModeInterval))
 	shouldReturn := false
 
 	for {
@@ -256,7 +258,7 @@ func (fm *Frontman) sendResultsChanToHubWithInterval(resultsChan chan Result) er
 			results = append(results, res)
 			// skip PostResultsToHub
 			continue
-		case <-sendResultsTicker:
+		case <-sendResultsTicker.C:
 			break
 		}
 
@@ -323,7 +325,7 @@ func (fm *Frontman) RunOnce(inputFilePath *string, outputFile *os.File, interrup
 }
 
 func (fm *Frontman) Run(inputFilePath *string, outputFile *os.File, interrupt chan struct{}) {
-	for true {
+	for {
 		err := fm.RunOnce(inputFilePath, outputFile, interrupt, false)
 		if err != nil {
 			log.Error(err)

--- a/handler.go
+++ b/handler.go
@@ -311,26 +311,24 @@ func (fm *Frontman) FetchInput(inputFilePath *string) (*Input, error) {
 	var input *Input
 	var err error
 
-	if inputFilePath == nil || *inputFilePath == "" {
-		// input file is not specified
-		// lets try to request the HUB
-		input, err = fm.InputFromHub()
+	if inputFilePath != nil && *inputFilePath != "" {
+		input, err = InputFromFile(*inputFilePath)
 		if err != nil {
-			if fm.HubUser != "" {
-				// it may be useful to log the Hub User that was used to do a HTTP Basic Auth
-				// e.g. in case of '401 Unauthorized' user can see the corresponding user in the logs
-
-				return nil, fmt.Errorf("InputFromHub(%s:***): %s", fm.HubUser, err.Error())
-			}
-
-			return nil, fmt.Errorf("InputFromHub: %s", err.Error())
+			return nil, fmt.Errorf("InputFromFile(%s) error: %s", *inputFilePath, err.Error())
 		}
 		return input, nil
 	}
 
-	input, err = InputFromFile(*inputFilePath)
+	// in case input file not specified this means we should request HUB instead
+	input, err = fm.InputFromHub()
 	if err != nil {
-		return nil, fmt.Errorf("InputFromFile(%s) error: %s", *inputFilePath, err.Error())
+		if fm.HubUser != "" {
+			// it may be useful to log the Hub User that was used to do a HTTP Basic Auth
+			// e.g. in case of '401 Unauthorized' user can see the corresponding user in the logs
+			return nil, fmt.Errorf("InputFromHub(%s:***): %s", fm.HubUser, err.Error())
+		}
+
+		return nil, fmt.Errorf("InputFromHub: %s", err.Error())
 	}
 
 	return input, nil

--- a/handler.go
+++ b/handler.go
@@ -324,8 +324,10 @@ func (fm *Frontman) RunOnce(inputFilePath *string, outputFile *os.File, interrup
 
 func (fm *Frontman) Run(inputFilePath *string, outputFile *os.File, interrupt chan struct{}) {
 	for true {
-		fm.RunOnce(inputFilePath, outputFile, interrupt, false)
-
+		err := fm.RunOnce(inputFilePath, outputFile, interrupt, false)
+		if err != nil {
+			log.Error(err)
+		}
 		select {
 		case <-interrupt:
 			return

--- a/handler.go
+++ b/handler.go
@@ -317,7 +317,9 @@ func (fm *Frontman) FetchInput(inputFilePath *string) (*Input, error) {
 		input, err = fm.InputFromHub()
 		if err != nil {
 			if fm.HubUser != "" {
-				// include Basic Auth login for the context if available
+				// it may be useful to log the Hub User that was used to do a HTTP Basic Auth
+				// e.g. in case of '401 Unauthorized' user can see the corresponding user in the logs
+
 				return nil, fmt.Errorf("InputFromHub(%s:***): %s", fm.HubUser, err.Error())
 			}
 

--- a/handler.go
+++ b/handler.go
@@ -323,6 +323,7 @@ func (fm *Frontman) FetchInput(inputFilePath *string) (*Input, error) {
 
 			return nil, fmt.Errorf("InputFromHub: %s", err.Error())
 		}
+		return input, nil
 	}
 
 	input, err = InputFromFile(*inputFilePath)

--- a/handler.go
+++ b/handler.go
@@ -285,11 +285,11 @@ func (fm *Frontman) RunOnce(inputFilePath *string, outputFile *os.File, interrup
 	if inputFilePath == nil || *inputFilePath == "" {
 		input, err = fm.InputFromHub()
 		if err != nil {
-			auth := ""
 			if fm.HubUser != "" {
-				auth = fmt.Sprintf(" (%s:***)", fm.HubUser)
+				return fmt.Errorf("InputFromHub(%s:***): %s", fm.HubUser, err.Error())
 			}
-			return fmt.Errorf("InputFromHub%s: %s", auth, err.Error())
+			
+			return fmt.Errorf("InputFromHub: %s", err.Error())
 		}
 	} else {
 		input, err = InputFromFile(*inputFilePath)


### PR DESCRIPTION
- split `Run()` method into `Run()` and `RunOnce()`
- take different results processing methods(file/continious file/hub wait/hub interval) out of `RunOnce()` 

gocyclo:
```
19 frontman (*Frontman).processInput handler.go:342:1
17 frontman (*Frontman).HostInfoResults handler.go:470:1
15 frontman (*Frontman).PostResultsToHub handler.go:109:1
13 frontman (*Frontman).RunOnce handler.go:281:1
```