### PR TITLE
set log level during creation of fonrman so it will be set for sure

### DIFF
--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -15,13 +15,12 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/cloudradar-monitoring/frontman"
 	"github.com/kardianos/service"
 	log "github.com/sirupsen/logrus"
-
-	"github.com/cloudradar-monitoring/frontman"
 )
 
-const defaultLogLevel = "error"
+const defaultLogLevel = frontman.LogLevelError
 
 var (
 	// set on build:
@@ -51,7 +50,7 @@ func askForConfirmation(s string) bool {
 }
 
 func main() {
-	fm := frontman.New()
+	fm := frontman.New(defaultLogLevel)
 	fm.SetVersion(version)
 
 	defer func() {
@@ -76,7 +75,7 @@ func main() {
 	outputFilePtr := flag.String("o", "", "file to write the results (default ./results.out)")
 
 	cfgPathPtr := flag.String("c", frontman.DefaultCfgPath, "config file path")
-	logLevelPtr := flag.String("v", defaultLogLevel, "log level – overrides the level in config file (values \"error\",\"info\",\"debug\")")
+	logLevelPtr := flag.String("v", string(defaultLogLevel), "log level – overrides the level in config file (values \"error\",\"info\",\"debug\")")
 	systemManager := service.ChosenSystem()
 	daemonizeModePtr := flag.Bool("d", false, "daemonize – run the proccess in background")
 	oneRunOnlyModePtr := flag.Bool("r", false, "one run only – perform checks once and exit. Overwrites output file")

--- a/config.go
+++ b/config.go
@@ -1,6 +1,7 @@
 package frontman
 
 import (
+	"bytes"
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"time"
-	"bytes"
 
 	"github.com/BurntSushi/toml"
 	log "github.com/sirupsen/logrus"
@@ -69,7 +69,7 @@ type Frontman struct {
 	version string
 }
 
-func New() *Frontman {
+func New(logLevel LogLevel) *Frontman {
 	var defaultLogPath string
 	var rootCertsPath string
 
@@ -105,6 +105,10 @@ func New() *Frontman {
 		SystemFields:           []string{},
 		hostInfoSent:           false,
 	}
+
+	// This is the default log level set
+	// Can be overwritten later by config file or flags
+	fm.SetLogLevel(logLevel)
 
 	if rootCertsPath != "" {
 		if _, err := os.Stat(rootCertsPath); err == nil {


### PR DESCRIPTION
Pass the initial log level to `frontman.New()` to be sure we have one set.
Can be overwritten later by config file or flags.

Closes #22 