### PR TITLE
refactor main.go

### DIFF
--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -119,7 +119,7 @@ func main() {
 
 	handleFlagPrintConfig(*printConfigPtr, fm)
 	handleFlagServiceUninstall(fm, *serviceUninstallPtr)
-	handleFlagServiceInstall(fm, serviceInstallUserPtr, serviceInstallPtr, *cfgPathPtr)
+	handleFlagServiceInstall(fm, systemManager, serviceInstallUserPtr, serviceInstallPtr, *cfgPathPtr)
 	handleFlagDaemonizeMode(*daemonizeModePtr)
 
 	// setup interrupt handler
@@ -292,7 +292,7 @@ func handleFlagServiceUninstall(fm *frontman.Frontman, serviceUninstallPtr bool)
 	os.Exit(0)
 }
 
-func handleFlagServiceInstall(fm *frontman.Frontman, serviceInstallUserPtr *string, serviceInstallPtr *bool, cfgPath string) {
+func handleFlagServiceInstall(fm *frontman.Frontman, systemManager service.System, serviceInstallUserPtr *string, serviceInstallPtr *bool, cfgPath string) {
 	// serviceInstallPtr is currently used on windows
 	// serviceInstallUserPtr is used on other systems
 	// if both of them are empty - just return
@@ -300,8 +300,6 @@ func handleFlagServiceInstall(fm *frontman.Frontman, serviceInstallUserPtr *stri
 		(serviceInstallPtr == nil || !*serviceInstallPtr) {
 		return
 	}
-
-	systemManager := service.ChosenSystem()
 
 	username := ""
 	if serviceInstallUserPtr != nil {
@@ -353,10 +351,10 @@ func handleFlagServiceInstall(fm *frontman.Frontman, serviceInstallUserPtr *stri
 			if askForConfirmation("Do you want to overwrite it?" + osSpecificNote) {
 				err = s.Stop()
 				if err != nil {
-					// lets try to uninstall despite of this error
 					fmt.Println("Failed to stop the service: ", err.Error())
 				}
 
+				// lets try to uninstall despite of this error
 				err := s.Uninstall()
 				if err != nil {
 					fmt.Println("Failed to unistall the service: ", err.Error())
@@ -403,7 +401,6 @@ func runUnderOsServiceManager(fm *frontman.Frontman) {
 
 	// we are running under OS service manager
 	err = systemService.Run()
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -35,22 +35,6 @@ var svcConfig = &service.Config{
 	Description: "Monitoring proxy for agentless monitoring of subnets",
 }
 
-func runUnderOsServiceManager(fm *frontman.Frontman) {
-	systemService, err := getServiceFromFlags(fm, "", "")
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	// we are running under OS service manager
-	err = systemService.Run()
-
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-
-	os.Exit(0)
-}
-
 func main() {
 	setDefaultLogFormatter()
 	systemManager := service.ChosenSystem()
@@ -402,6 +386,22 @@ install:
 	}
 
 	fmt.Printf("Logs file located at: %s\n", fm.LogFile)
+	os.Exit(0)
+}
+
+func runUnderOsServiceManager(fm *frontman.Frontman) {
+	systemService, err := getServiceFromFlags(fm, "", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// we are running under OS service manager
+	err = systemService.Run()
+
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+
 	os.Exit(0)
 }
 

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -342,7 +342,7 @@ func handleFlagServiceInstall(fm *frontman.Frontman, serviceInstallUserPtr *stri
 			fmt.Printf("Frontman service(%s) already installed: %s\n", systemManager.String(), err.Error())
 
 			if attempt == maxAttempts {
-				fmt.Println("Give up after %d attempts", attempt)
+				fmt.Printf("Give up after %d attempts\n", maxAttempts)
 				os.Exit(1)
 			}
 

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -20,13 +20,449 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const defaultLogLevel = "error"
+// set it in case user provided only input(-i) file
+const defaultOutputFile = "./results.out"
 
 var (
 	// set on build:
 	// go build -o frontman -ldflags="-X main.version=$(git --git-dir=src/github.com/cloudradar-monitoring/frontman/.git describe --always --long --dirty --tag)" github.com/cloudradar-monitoring/frontman/cmd/frontman
 	version string
 )
+
+var svcConfig = &service.Config{
+	Name:        "frontman",
+	DisplayName: "Frontman",
+	Description: "Monitoring proxy for agentless monitoring of subnets",
+}
+
+func main() {
+	fm := frontman.New(version)
+	setDefaultLogFormatter()
+	systemManager := service.ChosenSystem()
+
+	sigc := make(chan os.Signal, 1)
+	signal.Notify(sigc,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM)
+
+	var serviceInstallUserPtr *string
+	var serviceInstallPtr *bool
+
+	inputFilePtr := flag.String("i", "", "JSON file to read the list (required)")
+	outputFilePtr := flag.String("o", "", "file to write the results (default ./results.out)")
+
+	cfgPathPtr := flag.String("c", frontman.DefaultCfgPath, "config file path")
+	logLevelPtr := flag.String("v", "", "log level – overrides the level in config file (values \"error\",\"info\",\"debug\")")
+	daemonizeModePtr := flag.Bool("d", false, "daemonize – run the proccess in background")
+	oneRunOnlyModePtr := flag.Bool("r", false, "one run only – perform checks once and exit. Overwrites output file")
+
+	if runtime.GOOS == "windows" {
+		serviceInstallPtr = flag.Bool("s", false, fmt.Sprintf("install and start the system service(%s)", systemManager.String()))
+	} else {
+		serviceInstallUserPtr = flag.String("s", "", fmt.Sprintf("username to install and start the system service(%s)", systemManager.String()))
+	}
+
+	serviceUninstallPtr := flag.Bool("u", false, fmt.Sprintf("stop and uninstall the system service(%s)", systemManager.String()))
+	printConfigPtr := flag.Bool("p", false, "print the active config")
+	versionPtr := flag.Bool("version", false, "show the frontman version")
+
+	flag.Parse()
+
+	flagVersion(*versionPtr)
+
+	err := frontman.HandleConfig(fm, *cfgPathPtr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// process some of config params
+	err = fm.Initialize()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	flagLogLevel(fm, *logLevelPtr)
+	flagPrintConfig(*printConfigPtr, fm)
+
+	var osNotice string
+	if runtime.GOOS == "windows" && !frontman.CheckIfRawICMPAvailable() {
+		osNotice = "!!! You need to run frontman as administrator in order to use ICMP ping on Windows !!!"
+	}
+
+	if runtime.GOOS == "linux" && !frontman.CheckIfRootlessICMPAvailable() && !frontman.CheckIfRawICMPAvailable() {
+		osNotice = `⚠️ In order to perform rootless ICMP Ping on Linux you need to run this command first:
+		sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"`
+	}
+
+	if osNotice != "" {
+		// print to console without log formatting
+		fmt.Println(osNotice)
+
+		// disable logging to stderr temporarily
+		log.SetOutput(ioutil.Discard)
+		log.Error(osNotice)
+		log.SetOutput(os.Stderr)
+	}
+
+	writePidFileIfNeeded(fm, oneRunOnlyModePtr)
+	defer removePidFileIfNeeded(fm, oneRunOnlyModePtr)
+
+	systemService, err := getServiceFromFlags(fm, cfgPathPtr, serviceInstallUserPtr)
+
+	if !service.Interactive() {
+		// we are running under OS service manager
+		err = systemService.Run()
+
+		if err != nil {
+			log.Fatal(err.Error())
+		}
+
+		os.Exit(0)
+	}
+
+	flagServiceUninstall(systemService, *serviceUninstallPtr)
+
+	// check some incompatible flags
+	if serviceInstallUserPtr != nil && *serviceInstallUserPtr != "" ||
+		serviceInstallPtr != nil && *serviceInstallPtr {
+		if *inputFilePtr != "" {
+			fmt.Println("Input file(-i) flag can't be used together with service install(-s) flag")
+			os.Exit(1)
+		}
+
+		if *outputFilePtr != "" {
+			fmt.Println("Output file(-o) flag can't be used together with service install(-s) flag")
+			os.Exit(1)
+		}
+	}
+
+	flagServiceInstall(systemService, fm, serviceInstallUserPtr, serviceInstallPtr)
+	flagDaemonizeMode(*daemonizeModePtr)
+
+	output := flagInputOutput(*inputFilePtr, *outputFilePtr, *oneRunOnlyModePtr)
+
+	interruptChan := make(chan struct{})
+	flagOneRunOnlyMode(fm, *oneRunOnlyModePtr, *inputFilePtr, output, interruptChan)
+
+	// no any flag resulted in os.Exit
+	// so lets use the default continuous run mode
+	doneChan := make(chan struct{})
+	go func() {
+		fm.Run(*inputFilePtr, output, interruptChan)
+		doneChan <- struct{}{}
+	}()
+
+	select {
+	case sig := <-sigc:
+		log.Infof("Got %s signal. Finishing the batch and exit...", sig.String())
+		interruptChan <- struct{}{}
+		os.Exit(0)
+	case <-doneChan:
+		return
+	}
+}
+
+func flagVersion(versionFlag bool) {
+	if versionFlag {
+		fmt.Printf("frontman v%s released under MIT license. https://github.com/cloudradar-monitoring/frontman/\n", version)
+		os.Exit(0)
+	}
+}
+
+func flagPrintConfig(printConfig bool, fm *frontman.Frontman) {
+	if printConfig {
+		fmt.Println(fm.DumpConfigToml())
+		os.Exit(0)
+	}
+}
+
+func flagLogLevel(fm *frontman.Frontman, logLevel string) {
+	// Check loglevel and if needed warn user and set to default
+	if logLevel == string(frontman.LogLevelError) || logLevel == string(frontman.LogLevelInfo) || logLevel == string(frontman.LogLevelDebug) {
+		fm.SetLogLevel(frontman.LogLevel(logLevel))
+	} else if logLevel != "" {
+		log.Warnf("Invalid log level: \"%s\". Set to default: \"%s\"", logLevel, fm.LogLevel)
+	}
+}
+
+func flagInputOutput(inputFile string, outputFile string, oneRunOnlyMode bool) (output *os.File) {
+	if outputFile != "" && inputFile == "" {
+		fmt.Println("Output(-o) flag can be only used together with input(-i)")
+		os.Exit(1)
+	}
+
+	if inputFile == "" {
+		return nil
+	}
+
+	if inputFile != "" && outputFile == "" {
+		fmt.Printf("Output file not specified. Will use the default one: %s\n", defaultOutputFile)
+		outputFile = defaultOutputFile
+	}
+
+	if outputFile == "-" {
+		log.SetOutput(ioutil.Discard)
+		output = os.Stdout
+	} else {
+		if _, err := os.Stat(outputFile); os.IsNotExist(err) {
+			dir := filepath.Dir(outputFile)
+			if _, err := os.Stat(dir); os.IsNotExist(err) {
+				err = os.MkdirAll(dir, 0644)
+				if err != nil {
+					log.WithError(err).Errorf("Failed to create the output file directory: '%s'", dir)
+				}
+			}
+		}
+
+		mode := os.O_WRONLY | os.O_CREATE
+
+		if oneRunOnlyMode {
+			mode = mode | os.O_TRUNC
+		} else {
+			mode = mode | os.O_APPEND
+		}
+
+		var err error
+		output, err = os.OpenFile(outputFile, mode, 0644)
+		defer output.Close()
+
+		if err != nil {
+			log.WithError(err).Fatalf("Failed to open the output file: '%s'", outputFile)
+		}
+	}
+
+	return
+}
+
+func flagOneRunOnlyMode(fm *frontman.Frontman, oneRunOnlyMode bool, inputFile string, output *os.File, interruptChan chan struct{}) {
+	if oneRunOnlyMode {
+		input, err := fm.FetchInput(inputFile)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+
+		err = fm.RunOnce(input, output, interruptChan, false)
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+}
+
+func flagDaemonizeMode(daemonizeMode bool) {
+	if daemonizeMode && os.Getenv("FRONTMAN_FORK") != "1" {
+		err := rerunDetached()
+		if err != nil {
+			fmt.Println("Failed to fork process: ", err.Error())
+			os.Exit(1)
+		}
+
+		os.Exit(0)
+	}
+}
+
+func flagServiceUninstall(s service.Service, serviceUninstallPtr bool) {
+	if !serviceUninstallPtr {
+		return
+	}
+
+	err := s.Stop()
+	if err != nil {
+		// don't return error here, just write a warning and try to uninstall
+		fmt.Println("Failed to stop the service: ", err.Error())
+	}
+
+	err = s.Uninstall()
+	if err != nil {
+		fmt.Println("Failed to uninstall the service: ", err.Error())
+		os.Exit(1)
+	}
+
+	os.Exit(0)
+}
+
+func flagServiceInstall(s service.Service, fm *frontman.Frontman, serviceInstallUserPtr *string, serviceInstallPtr *bool) {
+	systemManager := service.ChosenSystem()
+
+	// serviceInstallPtr is currently used on windows
+	// serviceInstallUserPtr is used on other systems
+	// if both of them are empty - just return
+	if (serviceInstallUserPtr == nil || *serviceInstallUserPtr == "") &&
+		(serviceInstallPtr == nil || !*serviceInstallPtr) {
+		return
+	}
+
+	if fm.HubURL == "" {
+		fmt.Printf("To install the service you first need to set 'hub_url' config param")
+		os.Exit(1)
+	}
+
+	if runtime.GOOS != "windows" {
+		userName := *serviceInstallUserPtr
+		u, err := user.Lookup(userName)
+		if err != nil {
+			fmt.Printf("Failed to find the user '%s'\n", userName)
+			os.Exit(1)
+		}
+
+		svcConfig.UserName = userName
+		// we need to chown log file with user who will run service
+		// because installer can be run under root so the log file will be also created under root
+		err = chownFile(fm.LogFile, u)
+		if err != nil {
+			fmt.Printf("Failed to chown log file for '%s' user\n", userName)
+		}
+	}
+
+install:
+	err := s.Install()
+
+	if err != nil && strings.Contains(err.Error(), "already exists") {
+
+		fmt.Printf("Frontman service(%s) already installed: %s\n", systemManager.String(), err.Error())
+
+		note := ""
+		if runtime.GOOS == "windows" {
+			note = " Windows Services Manager app should not be opened!"
+		}
+		if askForConfirmation("Do you want to overwrite it?" + note) {
+			err = s.Stop()
+			err := s.Uninstall()
+			if err != nil {
+				fmt.Println("Failed to unistall the service: ", err.Error())
+				os.Exit(1)
+			}
+			goto install
+		}
+
+	} else if err != nil {
+		fmt.Printf("Frontman service(%s) installing error: %s\n", systemManager.String(), err.Error())
+		os.Exit(1)
+	}
+
+	fmt.Printf("Frontman service(%s) installed. Starting...\n", systemManager.String())
+	err = s.Start()
+	if err != nil {
+		fmt.Println("Already running")
+	}
+
+	switch systemManager.String() {
+	case "unix-systemv":
+		fmt.Printf("Run this command to stop it:\nsudo service %s stop\n\n", svcConfig.Name)
+	case "linux-upstart":
+		fmt.Printf("Run this command to stop it:\nsudo initctl stop %s\n\n", svcConfig.Name)
+	case "linux-systemd":
+		fmt.Printf("Run this command to stop it:\nsudo systemctl stop %s.service\n\n", svcConfig.Name)
+	case "darwin-launchd":
+		fmt.Printf("Run this command to stop it:\nsudo launchctl unload %s\n\n", svcConfig.Name)
+	case "windows-service":
+		fmt.Printf("Use the Windows Service Manager to stop it\n\n")
+	}
+
+	fmt.Printf("Logs file located at: %s\n", fm.LogFile)
+	os.Exit(0)
+}
+
+type serviceWrapper struct {
+	Frontman      *frontman.Frontman
+	InterruptChan chan struct{}
+	DoneChan      chan struct{}
+}
+
+func (sw *serviceWrapper) Start(s service.Service) error {
+	sw.InterruptChan = make(chan struct{})
+	sw.DoneChan = make(chan struct{})
+	go func() {
+		sw.Frontman.Run("", nil, sw.InterruptChan)
+		sw.DoneChan <- struct{}{}
+	}()
+
+	return nil
+}
+
+func (sw *serviceWrapper) Stop(s service.Service) error {
+	sw.InterruptChan <- struct{}{}
+	log.Println("Finishing the batch and stop the service...")
+	<-sw.DoneChan
+	return nil
+}
+
+func getServiceFromFlags(fm *frontman.Frontman, configPathPtr, userNamePtr *string) (service.Service, error) {
+	prg := &serviceWrapper{Frontman: fm}
+
+	if *configPathPtr != "" {
+		absCfgPath := *configPathPtr
+		if !filepath.IsAbs(absCfgPath) {
+			var err error
+			absCfgPath, err = filepath.Abs(*configPathPtr)
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get absolute path to config at '%s': %s", *configPathPtr, err)
+			}
+		}
+		svcConfig.Arguments = []string{"-c", absCfgPath}
+	}
+
+	if userNamePtr != nil {
+		svcConfig.UserName = *userNamePtr
+
+	}
+	return service.New(prg, svcConfig)
+}
+
+func writePidFileIfNeeded(fm *frontman.Frontman, oneRunOnlyModePtr *bool) {
+	if fm.PidFile != "" && !*oneRunOnlyModePtr && runtime.GOOS != "windows" {
+		err := ioutil.WriteFile(fm.PidFile, []byte(strconv.Itoa(os.Getpid())), 0664)
+		if err != nil {
+			log.Errorf("Failed to write pid file at: %s", fm.PidFile)
+		}
+	}
+}
+
+func removePidFileIfNeeded(fm *frontman.Frontman, oneRunOnlyModePtr *bool) {
+	if fm.PidFile != "" && !*oneRunOnlyModePtr && runtime.GOOS != "windows" {
+		err := os.Remove(fm.PidFile)
+		if err != nil {
+			log.Errorf("Failed to remove pid file at: %s", fm.PidFile)
+		}
+	}
+}
+
+func rerunDetached() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(os.Args[0], os.Args[1:]...)
+	cmd.Dir = cwd
+	cmd.Env = append(os.Environ(), "FRONTMAN_FORK=1")
+
+	err = cmd.Start()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Frontman will continue in background...\nPID %d", cmd.Process.Pid)
+
+	return cmd.Process.Release()
+}
+
+func chownFile(filePath string, u *user.User) error {
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return fmt.Errorf("Chown files: error converting UID(%s) to int", u.Uid)
+	}
+
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return fmt.Errorf("Chown files: error converting GID(%s) to int", u.Gid)
+	}
+
+	return os.Chown(filePath, uid, gid)
+}
 
 func askForConfirmation(s string) bool {
 	reader := bufio.NewReader(os.Stdin)
@@ -49,383 +485,11 @@ func askForConfirmation(s string) bool {
 	}
 }
 
-func main() {
-	fm := frontman.New(version)
-
-	defer func() {
-		if runtime.GOOS == "windows" {
-			_, err := os.Open("\\\\.\\PHYSICALDRIVE0")
-			if err != nil {
-				log.Errorf("Seems frontman(%s) doesn't have admin rights: %s", runtime.GOARCH, err.Error())
-			} else {
-				log.Infof("Seems frontman(%s) have admin rights!", runtime.GOARCH)
-			}
-		}
-	}()
-	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc,
-		syscall.SIGHUP,
-		syscall.SIGINT,
-		syscall.SIGTERM)
-
-	var serviceInstallUserPtr *string
-	var serviceInstallPtr *bool
-	inputFilePtr := flag.String("i", "", "JSON file to read the list (required)")
-	outputFilePtr := flag.String("o", "", "file to write the results (default ./results.out)")
-
-	cfgPathPtr := flag.String("c", frontman.DefaultCfgPath, "config file path")
-	logLevelPtr := flag.String("v", defaultLogLevel, "log level – overrides the level in config file (values \"error\",\"info\",\"debug\")")
-	systemManager := service.ChosenSystem()
-	daemonizeModePtr := flag.Bool("d", false, "daemonize – run the proccess in background")
-	oneRunOnlyModePtr := flag.Bool("r", false, "one run only – perform checks once and exit. Overwrites output file")
-
-	if runtime.GOOS == "windows" {
-		serviceInstallPtr = flag.Bool("s", false, fmt.Sprintf("install and start the system service(%s)", systemManager.String()))
-	} else {
-		serviceInstallUserPtr = flag.String("s", "", fmt.Sprintf("username to install and start the system service(%s)", systemManager.String()))
-	}
-
-	serviceUninstallPtr := flag.Bool("u", false, fmt.Sprintf("stop and uninstall the system service(%s)", systemManager.String()))
-	printConfigPtr := flag.Bool("p", false, "print the active config")
-	versionPtr := flag.Bool("version", false, "show the frontman version")
-
-	flag.Parse()
-
-	if *versionPtr {
-		fmt.Printf("frontman v%s released under MIT license. https://github.com/cloudradar-monitoring/frontman/\n", version)
-		return
-	}
+func setDefaultLogFormatter() {
 	tfmt := log.TextFormatter{FullTimestamp: true}
 	if runtime.GOOS == "windows" {
 		tfmt.DisableColors = true
 	}
 
 	log.SetFormatter(&tfmt)
-
-	err := frontman.HandleConfig(fm, *cfgPathPtr)
-	if err != nil {
-		return
-	}
-
-	err = fm.Initialize()
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	if *printConfigPtr {
-		fmt.Println(fm.DumpConfigToml())
-		return
-	}
-
-	var osNotice string
-
-	if runtime.GOOS == "windows" && !frontman.CheckIfRawICMPAvailable() {
-		osNotice = "!!! You need to run frontman as administrator in order to use ICMP ping on Windows !!!"
-	}
-
-	if runtime.GOOS == "linux" && !frontman.CheckIfRootlessICMPAvailable() && !frontman.CheckIfRawICMPAvailable() {
-		osNotice = `⚠️ In order to perform rootless ICMP Ping on Linux you need to run this command first:
-sudo sysctl -w net.ipv4.ping_group_range="0   2147483647"`
-	}
-
-	if osNotice != "" {
-		// print to console without log formatting
-		fmt.Println(osNotice)
-
-		// disable logging to stderr temporarily
-		log.SetOutput(ioutil.Discard)
-		log.Error(osNotice)
-		log.SetOutput(os.Stderr)
-	}
-
-	// Check loglevel and if needed warn user and set to default
-	if *logLevelPtr == string(frontman.LogLevelError) || *logLevelPtr == string(frontman.LogLevelInfo) || *logLevelPtr == string(frontman.LogLevelDebug) {
-		fm.SetLogLevel(frontman.LogLevel(*logLevelPtr))
-	} else {
-		log.Warnf("LogLevel was set to an invalid value: \"%s\". Set to default: \"%s\"", *logLevelPtr, defaultLogLevel)
-		fm.SetLogLevel(frontman.LogLevel(defaultLogLevel))
-	}
-
-	if (inputFilePtr == nil || *inputFilePtr == "") && fm.HubURL == "" && !*serviceUninstallPtr {
-		if serviceInstallPtr != nil && *serviceInstallPtr || serviceInstallUserPtr != nil && *serviceInstallUserPtr != "" {
-			fmt.Println(" ****** Before start you need to set 'hub_url' config param at ", *cfgPathPtr)
-		} else {
-			fmt.Println("Missing input file flag(-i) or hub_url param in config")
-			flag.PrintDefaults()
-			return
-		}
-	}
-
-	var output *os.File
-
-	if inputFilePtr != nil && *inputFilePtr != "" {
-
-		if outputFilePtr == nil || *outputFilePtr == "" {
-			*outputFilePtr = "./results.out"
-		}
-
-		if *outputFilePtr != "-" {
-
-			if _, err := os.Stat(*outputFilePtr); os.IsNotExist(err) {
-				dir := filepath.Dir(*outputFilePtr)
-				if _, err := os.Stat(dir); os.IsNotExist(err) {
-					err = os.MkdirAll(dir, 0644)
-					if err != nil {
-						log.WithError(err).Errorf("Failed to create the output file directory: '%s'", dir)
-					}
-				}
-			}
-
-			mode := os.O_WRONLY | os.O_CREATE
-
-			if *oneRunOnlyModePtr {
-				mode = mode | os.O_TRUNC
-			} else {
-				mode = mode | os.O_APPEND
-			}
-
-			output, err = os.OpenFile(*outputFilePtr, mode, 0644)
-			defer output.Close()
-
-			if err != nil {
-				log.WithError(err).Fatalf("Failed to open the output file: '%s'", *outputFilePtr)
-			}
-		} else {
-			log.SetOutput(ioutil.Discard)
-			output = os.Stdout
-		}
-
-	} else {
-		if outputFilePtr != nil && *outputFilePtr != "" {
-			fmt.Println("Output(-o) flag can be only used together with input(-i)")
-			return
-		}
-	}
-
-	if serviceInstallPtr != nil && *serviceInstallPtr || serviceInstallUserPtr != nil && *serviceInstallUserPtr != "" || *serviceUninstallPtr || !service.Interactive() {
-		prg := &serviceWrapper{Frontman: fm}
-		if cfgPathPtr != nil && *cfgPathPtr != frontman.DefaultCfgPath {
-			path := *cfgPathPtr
-			if !filepath.IsAbs(path) {
-				path, err = filepath.Abs(path)
-				if err != nil {
-					log.Fatalf("Failed to get absolute path to config at '%s': %s", path, err)
-				}
-			}
-			svcConfig.Arguments = []string{"-c", path}
-		}
-
-		s, err := service.New(prg, svcConfig)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-		if service.Interactive() {
-
-			if *serviceUninstallPtr {
-				err = s.Stop()
-				if err != nil {
-					fmt.Println("Failed to stop the service: ", err.Error())
-				}
-
-				err = s.Uninstall()
-
-				if err != nil {
-					fmt.Println("Failed to uninstall the service: ", err.Error())
-				}
-				return
-			}
-
-			if inputFilePtr != nil && *inputFilePtr != "" {
-				fmt.Println("Input file(-i) flag can't be used together with service install(-s) flag")
-				return
-			}
-			if outputFilePtr != nil && *outputFilePtr != "" {
-				fmt.Println("Output file(-o) flag can't be used together with service install(-s) flag")
-				return
-			}
-			if runtime.GOOS != "windows" {
-
-				u, err := user.Lookup(*serviceInstallUserPtr)
-				if err != nil {
-					log.Errorf("Failed to find the user '%s'", *serviceInstallUserPtr)
-					return
-				} else {
-					svcConfig.UserName = *serviceInstallUserPtr
-				}
-				defer func() {
-					uid, err := strconv.Atoi(u.Uid)
-					if err != nil {
-						log.Errorf("Chown files: error converting UID(%s) to int", u.Uid)
-						return
-					}
-
-					gid, err := strconv.Atoi(u.Gid)
-					if err != nil {
-						log.Errorf("Chown files: error converting GID(%s) to int", u.Gid)
-						return
-					}
-					os.Chown(fm.LogFile, uid, gid)
-				}()
-			}
-
-		install:
-			err = s.Install()
-
-			if err != nil && strings.Contains(err.Error(), "already exists") {
-
-				fmt.Printf("Frontman service(%s) already installed: %s\n", systemManager.String(), err.Error())
-
-				note := ""
-				if runtime.GOOS == "windows" {
-					note = " Windows Services Manager app should not be opened!"
-				}
-				if askForConfirmation("Do you want to overwrite it?" + note) {
-					s.Stop()
-					err := s.Uninstall()
-					if err != nil {
-						fmt.Printf("Failed to unistall the service: %s\n", err.Error())
-						return
-					}
-					goto install
-				}
-				s.Uninstall()
-
-			} else if err != nil {
-				fmt.Printf("Frontman service(%s) installing error: %s", systemManager.String(), err.Error())
-				return
-			} else {
-				fmt.Printf("Frontman service(%s) installed. Starting...\n", systemManager.String())
-			}
-
-			err = s.Start()
-
-			if err != nil {
-				fmt.Printf("Already running\n")
-			}
-
-			switch systemManager.String() {
-			case "unix-systemv":
-				fmt.Printf("Run this command to stop/start it:\nsudo service %s stop\nsudo service %s start\n\n", svcConfig.Name, svcConfig.Name)
-			case "linux-upstart":
-				fmt.Printf("Run this command to stop/start it:\nsudo initctl stop %s\nsudo initctl start %s\n\n", svcConfig.Name, svcConfig.Name)
-			case "linux-systemd":
-				fmt.Printf("Run this command to stop/start it:\nsudo systemctl stop %s.service\nsudo systemctl start %s.service\n\n", svcConfig.Name, svcConfig.Name)
-			case "darwin-launchd":
-				fmt.Printf("Run this command to stop/start it:\nsudo launchctl unload %s\nsudo launchctl load /Library/LaunchDaemons/%s.plist\n\n", svcConfig.Name, svcConfig.Name)
-			case "windows-service":
-				fmt.Printf("Use the Windows Service Manager to stop/start it\n\n")
-			}
-
-			fmt.Printf("Logs file located at: %s\n", fm.LogFile)
-			return
-		}
-
-		err = s.Run()
-
-		if err != nil {
-			log.Error(err.Error())
-		}
-
-		return
-	}
-
-	if *daemonizeModePtr && os.Getenv("FRONTMAN_FORK") != "1" {
-		rerunDetached()
-		log.SetOutput(ioutil.Discard)
-
-		return
-	}
-
-	interruptChan := make(chan struct{})
-	doneChan := make(chan struct{})
-
-	if fm.PidFile != "" && *oneRunOnlyModePtr && runtime.GOOS != "windows" {
-		err := ioutil.WriteFile(fm.PidFile, []byte(strconv.Itoa(os.Getpid())), 0664)
-		if err != nil {
-			log.Errorf("Failed to write pid file at: %s", fm.PidFile)
-		}
-	}
-
-	if *oneRunOnlyModePtr == true {
-		input, err := fm.FetchInput(inputFilePtr)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-
-		err = fm.RunOnce(input, output, interruptChan, false)
-		if err != nil {
-			log.Error(err)
-			return
-		}
-		return
-	} else {
-		go func() {
-			fm.Run(inputFilePtr, output, interruptChan)
-			doneChan <- struct{}{}
-		}()
-	}
-
-	select {
-	case sig := <-sigc:
-		log.Infof("Got %s signal. Finishing the batch and exit...", sig.String())
-		interruptChan <- struct{}{}
-		os.Exit(0)
-	case <-doneChan:
-		return
-	}
-
-}
-
-func rerunDetached() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command(os.Args[0], os.Args[1:]...)
-	cmd.Dir = cwd
-	cmd.Env = append(os.Environ(), "FRONTMAN_FORK=1")
-
-	err = cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Frontman will continue in background...\nPID %d", cmd.Process.Pid)
-
-	cmd.Process.Release()
-	return nil
-}
-
-type serviceWrapper struct {
-	Frontman      *frontman.Frontman
-	InterruptChan chan struct{}
-	DoneChan      chan struct{}
-}
-
-func (sw *serviceWrapper) Start(s service.Service) error {
-	sw.InterruptChan = make(chan struct{})
-	sw.DoneChan = make(chan struct{})
-	go func() {
-		s := ""
-		sw.Frontman.Run(&s, nil, sw.InterruptChan)
-		sw.DoneChan <- struct{}{}
-	}()
-
-	return nil
-}
-
-func (sw *serviceWrapper) Stop(s service.Service) error {
-	sw.InterruptChan <- struct{}{}
-	log.Println("Finishing the batch and stop the service...")
-	<-sw.DoneChan
-	return nil
-}
-
-var svcConfig = &service.Config{
-	Name:        "frontman",
-	DisplayName: "Frontman",
-	Description: "Monitoring proxy for agentless monitoring of subnets",
 }

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -336,6 +336,7 @@ func handleFlagServiceInstall(fm *frontman.Frontman, systemManager service.Syste
 	const maxAttempts = 3
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		err = s.Install()
+		// Check error case where the service already exists
 		if err != nil && strings.Contains(err.Error(), "already exists") {
 			fmt.Printf("Frontman service(%s) already installed: %s\n", systemManager.String(), err.Error())
 
@@ -362,9 +363,11 @@ func handleFlagServiceInstall(fm *frontman.Frontman, systemManager service.Syste
 				}
 			}
 
+			// Check general error case
 		} else if err != nil {
 			fmt.Printf("Frontman service(%s) installing error: %s\n", systemManager.String(), err.Error())
 			os.Exit(1)
+			// Service install was success so we can exit the loop
 		} else {
 			break
 		}

--- a/config.go
+++ b/config.go
@@ -289,13 +289,12 @@ func HandleConfig(fm *Frontman, configFilePath string) error {
 		}
 	} else if err != nil {
 		if strings.Contains(err.Error(), "cannot load TOML value of type int64 into a Go float") {
-			log.Fatalf("Config load error: please use numbers with a decimal point for numerical values")
-		} else {
-			log.Fatalf("Config load error: %s", err.Error())
+			return fmt.Errorf("Config load error: please use numbers with a decimal point for numerical values")
 		}
+
+		return fmt.Errorf("Config load error: %s", err.Error())
 	}
 
 	fm.ApplyEnv()
-
-	return err
+	return nil
 }

--- a/config.go
+++ b/config.go
@@ -18,6 +18,8 @@ import (
 )
 
 const (
+	defaultLogLevel = "error"
+
 	IOModeFile = "file"
 	IOModeHTTP = "http"
 
@@ -82,7 +84,6 @@ type Frontman struct {
 	version string
 }
 
-// New returns an intialiased instance of Frontman
 func New(version string) *Frontman {
 	var defaultLogPath string
 	var rootCertsPath string
@@ -110,6 +111,7 @@ func New(version string) *Frontman {
 		version:                version,
 		IOMode:                 "http",
 		LogFile:                defaultLogPath,
+		LogLevel:               defaultLogLevel,
 		ICMPTimeout:            0.1,
 		Sleep:                  30,
 		SenderMode:             SenderModeWait,
@@ -226,7 +228,7 @@ func CreateDefaultConfigFile(configFilePath string) error {
 		return fmt.Errorf("failed to write headline to config file")
 	}
 
-	cfg := MinValuableConfig {
+	cfg := MinValuableConfig{
 		IOMode: "http",
 	}
 
@@ -265,6 +267,10 @@ func (fm *Frontman) Initialize() error {
 		if err != nil {
 			log.Error("Can't set up syslog: ", err.Error())
 		}
+	}
+
+	if fm.LogLevel != "" {
+		log.SetLevel(fm.LogLevel.LogrusLevel())
 	}
 
 	return nil


### PR DESCRIPTION
- split main() into separate `flagXyz()` functions that should process the flag and if needed do `os.Exit` with 0 or 1 status on their own
- fix default LogLevel. Do not set the default for flag so we can check if a user really set the flag. So it will be clear precedence from lowest to high (default -> config -> flag)

main() is still pretty big but I think this is a good balance. It shouldn't provide one clear purpose. It needs to:
 - create flags
 - check flags in the right order
 - run different initialization methods in the right order
 - run the main app in the end if needed

gocyclo before: 
```
85 main main main.go:52:1
```

gocyclo after: 
```
24 main flagServiceInstall main.go:298:1
19 main main main.go:54:1
12 main flagInputOutput main.go:196:1
```