### PR TITLE
Fix sending hostInfo

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -112,7 +112,6 @@ func (fm *Frontman) PostResultsToHub(results []Result) error {
 	fm.initHubHttpClient()
 
 	fm.offlineResultsBuffer = append(fm.offlineResultsBuffer, results...)
-	// Bundle hostInfo and results
 	b, err := json.Marshal(Results{
 		Results: fm.offlineResultsBuffer,
 	})
@@ -167,13 +166,6 @@ func (fm *Frontman) PostResultsToHub(results []Result) error {
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 		return errors.New(resp.Status)
-	}
-
-	// We assume the hostInfo was successfully sent because the responnse code
-	// was ok and hostInfo will only be sent if the flag was flase before.
-	if !fm.hostInfoSent {
-		fm.hostInfoSent = true
-		log.Debugf("hostInfoSent was set to true")
 	}
 
 	// in case of successful POST reset the offline buffer

--- a/handler.go
+++ b/handler.go
@@ -278,16 +278,15 @@ func (fm *Frontman) RunOnce(input *Input, outputFile *os.File, interrupt chan st
 	// since fm.Run calls fm.RunOnce over and over again, we need this check here
 	if !fm.hostInfoSent {
 		hostInfo, err = fm.HostInfoResults()
-		// TODO: Do we need special handling in error case? Send a special error object to the hub?
 		if err != nil {
 			log.Warnf("Failed to fetch HostInfo: %s", err)
 			hostInfo["error"] = err.Error()
 		}
 
-		// Send our hostInfo as first result
-		// TODO: Is this ok? Do we need to set more values?
+		// Send hostInfo as first result
 		resultsChan <- Result{
 			Measurements: hostInfo,
+			CheckType:    "hostInfo",
 			Timestamp:    time.Now().Unix(),
 		}
 		fm.hostInfoSent = true


### PR DESCRIPTION
At the moment `hostInfo` is only sent when sending data to hub.
It should also be included for the other forms of output

`HostInfo` is now sent within a `Result` struct as the first result when frontman is started.
This way we have it passed to all possible outputs without changing them.

The receiving side is responsible for handling the `hostInfo` properly. Therefor the `checkType` is set to `hostInfo`.