### PR TITLE
Improve service install/uninstall flow

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,11 +38,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:2c4470d47613daac5ff660ff9b67a6f8dca489845bb867186e3fcda742a3e53f"
+  digest = "1:833906243c69267906c5935dbda058540be450f4e545248cd5c5907c06991a5a"
   name = "github.com/kardianos/service"
   packages = ["."]
   pruneopts = "UT"
-  revision = "615a14ed75099c9eaac6949e22ac2341bf9d3197"
+  revision = "4c239ee84e7bb93441b1b6a3f2db62d40e0e6cbd"
 
 [[projects]]
   digest = "1:0028cb19b2e4c3112225cd871870f2d9cf49b9b4276531f03438a88e94be86fe"

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -290,13 +290,20 @@ func handleFlagServiceUninstall(fm *frontman.Frontman, serviceUninstallPtr bool)
 
 	systemService, err := getServiceFromFlags(fm, "", "")
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("Failed to get system service: %s", err.Error())
 	}
 
-	err = systemService.Stop()
+	status, err := systemService.Status()
 	if err != nil {
-		// don't return error here, just write a warning and try to uninstall
-		fmt.Println("Failed to stop the service: ", err.Error())
+		fmt.Println("Failed to get service status: ", err.Error())
+	}
+
+	if status == service.StatusRunning {
+		err = systemService.Stop()
+		if err != nil {
+			// don't exit here, just write a warning and try to uninstall
+			fmt.Println("Failed to stop the running service: ", err.Error())
+		}
 	}
 
 	err = systemService.Uninstall()

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -328,11 +328,6 @@ func handleFlagServiceInstall(fm *frontman.Frontman, systemManager service.Syste
 		os.Exit(1)
 	}
 
-	if fm.Config.HubURL == "" {
-		fmt.Printf("To install the service you first need to set 'hub_url' config param")
-		os.Exit(1)
-	}
-
 	if runtime.GOOS != "windows" {
 		userName := *serviceInstallUserPtr
 		u, err := user.Lookup(userName)
@@ -395,20 +390,16 @@ func handleFlagServiceInstall(fm *frontman.Frontman, systemManager service.Syste
 		fmt.Println(err.Error())
 	}
 
-	switch systemManager.String() {
-	case "unix-systemv":
-		fmt.Printf("Run this command to stop it:\nsudo service %s stop\n\n", svcConfig.Name)
-	case "linux-upstart":
-		fmt.Printf("Run this command to stop it:\nsudo initctl stop %s\n\n", svcConfig.Name)
-	case "linux-systemd":
-		fmt.Printf("Run this command to stop it:\nsudo systemctl stop %s.service\n\n", svcConfig.Name)
-	case "darwin-launchd":
-		fmt.Printf("Run this command to stop it:\nsudo launchctl unload %s\n\n", svcConfig.Name)
-	case "windows-service":
-		fmt.Printf("Use the Windows Service Manager to stop it\n\n")
+	fmt.Printf("Log file located at: %s\n", fm.Config.LogFile)
+	fmt.Printf("Config file located at: %s\n", cfgPath)
+
+	if fm.Config.HubURL == "" {
+		fmt.Printf(`*** Attention: 'hub_url' config param is empty.\n
+*** You need to put the right credentials from your Cloudradar account into the config and then restart the service\n\n`)
 	}
 
-	fmt.Printf("Log file located at: %s\n", fm.Config.LogFile)
+	fmt.Printf("Run this command to restart the service: %s\n\n", getSystemMangerCommand(systemManager.String(), svcConfig.Name, "restart"))
+
 	os.Exit(0)
 }
 
@@ -554,4 +545,29 @@ func setDefaultLogFormatter() {
 	}
 
 	log.SetFormatter(&tfmt)
+}
+
+func getSystemMangerCommand(manager string, service string, command string) string {
+	switch manager {
+	case "unix-systemv":
+		return "sudo service " + service + " " + command
+	case "linux-upstart":
+		return "sudo initctl " + command + " " + service
+	case "linux-systemd":
+		return "sudo systemctl " + command + " " + service + ".service"
+	case "darwin-launchd":
+		switch command {
+		case "stop":
+			command = "unload"
+		case "start":
+			command = "load"
+		case "restart":
+			return "sudo launchctl unload " + service + " && sudo launchctl load " + service
+		}
+		return "sudo launchctl " + command + " " + service
+	case "windows-service":
+		return "sc " + command + " " + service
+	default:
+		return ""
+	}
 }

--- a/pkg-scripts/preremove.sh
+++ b/pkg-scripts/preremove.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-/usr/bin/frontman -u
+/usr/bin/frontman -u || true

--- a/vendor/github.com/kardianos/service/.travis.yml
+++ b/vendor/github.com/kardianos/service/.travis.yml
@@ -3,9 +3,8 @@ go_import_path: github.com/kardianos/service
 sudo: required
 
 go:
-  - 1.8.x
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
   - master
 
 before_install:

--- a/vendor/github.com/kardianos/service/service.go
+++ b/vendor/github.com/kardianos/service/service.go
@@ -75,10 +75,27 @@ const (
 	optionUserServiceDefault   = false
 	optionSessionCreate        = "SessionCreate"
 	optionSessionCreateDefault = false
+	optionLogOutput            = "LogOutput"
+	optionLogOutputDefault     = false
 
 	optionRunWait      = "RunWait"
 	optionReloadSignal = "ReloadSignal"
 	optionPIDFile      = "PIDFile"
+
+	optionSystemdScript = "SystemdScript"
+	optionSysvScript    = "SysvScript"
+	optionUpstartScript = "UpstartScript"
+	optionLaunchdConfig = "LaunchdConfig"
+)
+
+// Status represents service status as an byte value
+type Status byte
+
+// Status of service represented as an byte
+const (
+	StatusUnknown Status = iota // Status is unable to be determined due to an error or it was not installed.
+	StatusRunning
+	StatusStopped
 )
 
 // Config provides the setup for a Service. The Name field is required.
@@ -103,14 +120,19 @@ type Config struct {
 
 	// System specific options.
 	//  * OS X
-	//    - KeepAlive     bool (true)
-	//    - RunAtLoad     bool (false)
-	//    - UserService   bool (false) - Install as a current user service.
-	//    - SessionCreate bool (false) - Create a full user session.
+	//    - LaunchdConfig string ()      - Use custom launchd config
+	//    - KeepAlive     bool   (true)
+	//    - RunAtLoad     bool   (false)
+	//    - UserService   bool   (false) - Install as a current user service.
+	//    - SessionCreate bool   (false) - Create a full user session.
 	//  * POSIX
-	//    - RunWait      func() (wait for SIGNAL) - Do not install signal but wait for this function to return.
-	//    - ReloadSignal string () [USR1, ...] - Signal to send on reaload.
-	//    - PIDFile     string () [/run/prog.pid] - Location of the PID file.
+	//    - SystemdScript string ()                 - Use custom systemd script
+	//    - UpstartScript string ()                 - Use custom upstart script
+	//    - SysvScript    string ()                 - Use custom sysv script
+	//    - RunWait       func() (wait for SIGNAL)  - Do not install signal but wait for this function to return.
+	//    - ReloadSignal  string () [USR1, ...]     - Signal to send on reaload.
+	//    - PIDFile       string () [/run/prog.pid] - Location of the PID file.
+	//    - LogOutput     bool   (false)            - Redirect StdErr & StdOut to files.
 	Option KeyValue
 }
 
@@ -120,10 +142,12 @@ var (
 )
 
 var (
-	// ErrNameFieldRequired is returned when Conifg.Name is empty.
+	// ErrNameFieldRequired is returned when Config.Name is empty.
 	ErrNameFieldRequired = errors.New("Config.Name field is required.")
 	// ErrNoServiceSystemDetected is returned when no system was detected.
 	ErrNoServiceSystemDetected = errors.New("No service system detected.")
+	// ErrNotInstalled is returned when the service is not installed
+	ErrNotInstalled = errors.New("the service is not installed")
 )
 
 // New creates a new service based on a service interface and configuration.
@@ -322,6 +346,13 @@ type Service interface {
 	// String displays the name of the service. The display name if present,
 	// otherwise the name.
 	String() string
+
+	// Platform displays the name of the system that manages the service.
+	// In most cases this will be the same as service.Platform().
+	Platform() string
+
+	// Status returns the current service status.
+	Status() (Status, error)
 }
 
 // ControlAction list valid string texts to use in Control.

--- a/vendor/github.com/kardianos/service/service_darwin.go
+++ b/vendor/github.com/kardianos/service/service_darwin.go
@@ -11,6 +11,8 @@ import (
 	"os/signal"
 	"os/user"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"syscall"
 	"text/template"
 	"time"
@@ -75,6 +77,10 @@ func (s *darwinLaunchdService) String() string {
 	return s.Name
 }
 
+func (s *darwinLaunchdService) Platform() string {
+	return version
+}
+
 func (s *darwinLaunchdService) getHomeDir() (string, error) {
 	u, err := user.Current()
 	if err == nil {
@@ -98,6 +104,25 @@ func (s *darwinLaunchdService) getServiceFilePath() (string, error) {
 		return homeDir + "/Library/LaunchAgents/" + s.Name + ".plist", nil
 	}
 	return "/Library/LaunchDaemons/" + s.Name + ".plist", nil
+}
+
+func (s *darwinLaunchdService) template() *template.Template {
+	functions := template.FuncMap{
+		"bool": func(v bool) string {
+			if v {
+				return "true"
+			}
+			return "false"
+		},
+	}
+
+	customConfig := s.Option.string(optionLaunchdConfig, "")
+
+	if customConfig != "" {
+		return template.Must(template.New("").Funcs(functions).Parse(customConfig))
+	} else {
+		return template.Must(template.New("").Funcs(functions).Parse(launchdConfig))
+	}
 }
 
 func (s *darwinLaunchdService) Install() error {
@@ -143,16 +168,7 @@ func (s *darwinLaunchdService) Install() error {
 		SessionCreate: s.Option.bool(optionSessionCreate, optionSessionCreateDefault),
 	}
 
-	functions := template.FuncMap{
-		"bool": func(v bool) string {
-			if v {
-				return "true"
-			}
-			return "false"
-		},
-	}
-	t := template.Must(template.New("launchdConfig").Funcs(functions).Parse(launchdConfig))
-	return t.Execute(f, to)
+	return s.template().Execute(f, to)
 }
 
 func (s *darwinLaunchdService) Uninstall() error {
@@ -163,6 +179,32 @@ func (s *darwinLaunchdService) Uninstall() error {
 		return err
 	}
 	return os.Remove(confPath)
+}
+
+func (s *darwinLaunchdService) Status() (Status, error) {
+	exitCode, out, err := runWithOutput("launchctl", "list", s.Name)
+	if exitCode == 0 && err != nil {
+		if !strings.Contains(err.Error(), "failed with stderr") {
+			return StatusUnknown, err
+		}
+	}
+
+	re := regexp.MustCompile(`"PID" = ([0-9]+);`)
+	matches := re.FindStringSubmatch(out)
+	if len(matches) == 2 {
+		return StatusRunning, nil
+	}
+
+	confPath, err := s.getServiceFilePath()
+	if err != nil {
+		return StatusUnknown, err
+	}
+
+	if _, err = os.Stat(confPath); err == nil {
+		return StatusStopped, nil
+	}
+
+	return StatusUnknown, ErrNotInstalled
 }
 
 func (s *darwinLaunchdService) Start() error {

--- a/vendor/github.com/kardianos/service/service_linux.go
+++ b/vendor/github.com/kardianos/service/service_linux.go
@@ -13,7 +13,7 @@ type linuxSystemService struct {
 	name        string
 	detect      func() bool
 	interactive func() bool
-	new         func(i Interface, c *Config) (Service, error)
+	new         func(i Interface, platform string, c *Config) (Service, error)
 }
 
 func (sc linuxSystemService) String() string {
@@ -26,7 +26,7 @@ func (sc linuxSystemService) Interactive() bool {
 	return sc.interactive()
 }
 func (sc linuxSystemService) New(i Interface, c *Config) (Service, error) {
-	return sc.new(i, c)
+	return sc.new(i, sc.String(), c)
 }
 
 func init() {

--- a/vendor/github.com/kardianos/service/service_sysv_linux.go
+++ b/vendor/github.com/kardianos/service/service_sysv_linux.go
@@ -9,20 +9,23 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"text/template"
 	"time"
 )
 
 type sysv struct {
-	i Interface
+	i        Interface
+	platform string
 	*Config
 }
 
-func newSystemVService(i Interface, c *Config) (Service, error) {
+func newSystemVService(i Interface, platform string, c *Config) (Service, error) {
 	s := &sysv{
-		i:      i,
-		Config: c,
+		i:        i,
+		platform: platform,
+		Config:   c,
 	}
 
 	return s, nil
@@ -35,6 +38,10 @@ func (s *sysv) String() string {
 	return s.Name
 }
 
+func (s *sysv) Platform() string {
+	return s.platform
+}
+
 var errNoUserServiceSystemV = errors.New("User services are not supported on SystemV.")
 
 func (s *sysv) configPath() (cp string, err error) {
@@ -45,8 +52,15 @@ func (s *sysv) configPath() (cp string, err error) {
 	cp = "/etc/init.d/" + s.Config.Name
 	return
 }
+
 func (s *sysv) template() *template.Template {
-	return template.Must(template.New("").Funcs(tf).Parse(sysvScript))
+	customScript := s.Option.string(optionSysvScript, "")
+
+	if customScript != "" {
+		return template.Must(template.New("").Funcs(tf).Parse(customScript))
+	} else {
+		return template.Must(template.New("").Funcs(tf).Parse(sysvScript))
+	}
 }
 
 func (s *sysv) Install() error {
@@ -134,6 +148,22 @@ func (s *sysv) Run() (err error) {
 	})()
 
 	return s.i.Stop(s)
+}
+
+func (s *sysv) Status() (Status, error) {
+	_, out, err := runWithOutput("service", s.Name, "status")
+	if err != nil {
+		return StatusUnknown, err
+	}
+
+	switch {
+	case strings.HasPrefix(out, "Running"):
+		return StatusRunning, nil
+	case strings.HasPrefix(out, "Stopped"):
+		return StatusStopped, nil
+	default:
+		return StatusUnknown, ErrNotInstalled
+	}
 }
 
 func (s *sysv) Start() error {

--- a/vendor/github.com/kardianos/service/service_unix.go
+++ b/vendor/github.com/kardianos/service/service_unix.go
@@ -8,9 +8,11 @@ package service
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log/syslog"
 	"os/exec"
+	"syscall"
 )
 
 func newSysLogger(name string, errs chan<- error) (Logger, error) {
@@ -53,20 +55,43 @@ func (s sysLogger) Infof(format string, a ...interface{}) error {
 }
 
 func run(command string, arguments ...string) error {
+	_, _, err := runCommand(command, false, arguments...)
+	return err
+}
+
+func runWithOutput(command string, arguments ...string) (int, string, error) {
+	return runCommand(command, true, arguments...)
+}
+
+func runCommand(command string, readStdout bool, arguments ...string) (int, string, error) {
 	cmd := exec.Command(command, arguments...)
+
+	var output string
+	var stdout io.ReadCloser
+	var err error
+
+	if readStdout {
+		// Connect pipe to read Stdout
+		stdout, err = cmd.StdoutPipe()
+
+		if err != nil {
+			// Failed to connect pipe
+			return 0, "", fmt.Errorf("%q failed to connect stdout pipe: %v", command, err)
+		}
+	}
 
 	// Connect pipe to read Stderr
 	stderr, err := cmd.StderrPipe()
 
 	if err != nil {
 		// Failed to connect pipe
-		return fmt.Errorf("%q failed to connect stderr pipe: %v", command, err)
+		return 0, "", fmt.Errorf("%q failed to connect stderr pipe: %v", command, err)
 	}
 
 	// Do not use cmd.Run()
 	if err := cmd.Start(); err != nil {
 		// Problem while copying stdin, stdout, or stderr
-		return fmt.Errorf("%q failed: %v", command, err)
+		return 0, "", fmt.Errorf("%q failed: %v", command, err)
 	}
 
 	// Zero exit status
@@ -75,14 +100,39 @@ func run(command string, arguments ...string) error {
 	if command == "launchctl" {
 		slurp, _ := ioutil.ReadAll(stderr)
 		if len(slurp) > 0 {
-			return fmt.Errorf("%q failed with stderr: %s", command, slurp)
+			return 0, "", fmt.Errorf("%q failed with stderr: %s", command, slurp)
+		}
+	}
+
+	if readStdout {
+		out, err := ioutil.ReadAll(stdout)
+		if err != nil {
+			return 0, "", fmt.Errorf("%q failed while attempting to read stdout: %v", command, err)
+		} else if len(out) > 0 {
+			output = string(out)
 		}
 	}
 
 	if err := cmd.Wait(); err != nil {
-		// Command didn't exit with a zero exit status.
-		return fmt.Errorf("%q failed: %v", command, err)
+		exitStatus, ok := isExitError(err)
+		if ok {
+			// Command didn't exit with a zero exit status.
+			return exitStatus, output, err
+		}
+
+		// An error occurred and there is no exit status.
+		return 0, output, fmt.Errorf("%q failed: %v", command, err)
 	}
 
-	return nil
+	return 0, output, nil
+}
+
+func isExitError(err error) (int, bool) {
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus(), true
+		}
+	}
+
+	return 0, false
 }

--- a/vendor/github.com/kardianos/service/service_upstart_linux.go
+++ b/vendor/github.com/kardianos/service/service_upstart_linux.go
@@ -8,11 +8,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/signal"
 	"regexp"
-	"strconv"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 )
@@ -21,9 +20,9 @@ func isUpstart() bool {
 	if _, err := os.Stat("/sbin/upstart-udev-bridge"); err == nil {
 		return true
 	}
-	if _, err := os.Stat("/sbin/init"); err == nil {
-		if out, err := exec.Command("/sbin/init", "--version").Output(); err == nil {
-			if strings.Contains(string(out), "init (upstart") {
+	if _, err := os.Stat("/sbin/initctl"); err == nil {
+		if _, out, err := runWithOutput("/sbin/initctl", "--version"); err == nil {
+			if strings.Contains(out, "initctl (upstart") {
 				return true
 			}
 		}
@@ -32,14 +31,16 @@ func isUpstart() bool {
 }
 
 type upstart struct {
-	i Interface
+	i        Interface
+	platform string
 	*Config
 }
 
-func newUpstartService(i Interface, c *Config) (Service, error) {
+func newUpstartService(i Interface, platform string, c *Config) (Service, error) {
 	s := &upstart{
-		i:      i,
-		Config: c,
+		i:        i,
+		platform: platform,
+		Config:   c,
 	}
 
 	return s, nil
@@ -50,6 +51,10 @@ func (s *upstart) String() string {
 		return s.DisplayName
 	}
 	return s.Name
+}
+
+func (s *upstart) Platform() string {
+	return s.platform
 }
 
 // Upstart has some support for user services in graphical sessions.
@@ -68,46 +73,57 @@ func (s *upstart) configPath() (cp string, err error) {
 
 func (s *upstart) hasKillStanza() bool {
 	defaultValue := true
-
-	out, err := exec.Command("/sbin/init", "--version").Output()
-	if err != nil {
+	version := s.getUpstartVersion()
+	if version == nil {
 		return defaultValue
-	}
-
-	re := regexp.MustCompile(`init \(upstart (\d+.\d+.\d+)\)`)
-	matches := re.FindStringSubmatch(string(out))
-	if len(matches) != 2 {
-		return defaultValue
-	}
-
-	version := make([]int, 3)
-	for idx, vStr := range strings.Split(matches[1], ".") {
-		version[idx], err = strconv.Atoi(vStr)
-		if err != nil {
-			return defaultValue
-		}
 	}
 
 	maxVersion := []int{0, 6, 5}
-	if versionAtMost(version, maxVersion) {
+	if matches, err := versionAtMost(version, maxVersion); err != nil || matches {
 		return false
 	}
 
 	return defaultValue
 }
 
-func versionAtMost(version, max []int) bool {
-	for idx, m := range max {
-		v := version[idx]
-		if v > m {
-			return false
-		}
+func (s *upstart) hasSetUIDStanza() bool {
+	defaultValue := true
+	version := s.getUpstartVersion()
+	if version == nil {
+		return defaultValue
 	}
-	return true
+
+	maxVersion := []int{1, 4, 0}
+	if matches, err := versionAtMost(version, maxVersion); err != nil || matches {
+		return false
+	}
+
+	return defaultValue
+}
+
+func (s *upstart) getUpstartVersion() []int {
+	_, out, err := runWithOutput("/sbin/initctl", "--version")
+	if err != nil {
+		return nil
+	}
+
+	re := regexp.MustCompile(`initctl \(upstart (\d+.\d+.\d+)\)`)
+	matches := re.FindStringSubmatch(out)
+	if len(matches) != 2 {
+		return nil
+	}
+
+	return parseVersion(matches[1])
 }
 
 func (s *upstart) template() *template.Template {
-	return template.Must(template.New("").Funcs(tf).Parse(upstartScript))
+	customScript := s.Option.string(optionUpstartScript, "")
+
+	if customScript != "" {
+		return template.Must(template.New("").Funcs(tf).Parse(customScript))
+	} else {
+		return template.Must(template.New("").Funcs(tf).Parse(upstartScript))
+	}
 }
 
 func (s *upstart) Install() error {
@@ -133,12 +149,16 @@ func (s *upstart) Install() error {
 
 	var to = &struct {
 		*Config
-		Path          string
-		HasKillStanza bool
+		Path            string
+		HasKillStanza   bool
+		HasSetUIDStanza bool
+		LogOutput       bool
 	}{
 		s.Config,
 		path,
 		s.hasKillStanza(),
+		s.hasSetUIDStanza(),
+		s.Option.bool(optionLogOutput, optionLogOutputDefault),
 	}
 
 	return s.template().Execute(f, to)
@@ -173,11 +193,27 @@ func (s *upstart) Run() (err error) {
 
 	s.Option.funcSingle(optionRunWait, func() {
 		var sigChan = make(chan os.Signal, 3)
-		signal.Notify(sigChan, os.Interrupt, os.Kill)
+		signal.Notify(sigChan, syscall.SIGTERM, os.Interrupt)
 		<-sigChan
 	})()
 
 	return s.i.Stop(s)
+}
+
+func (s *upstart) Status() (Status, error) {
+	exitCode, out, err := runWithOutput("initctl", "status", s.Name)
+	if exitCode == 0 && err != nil {
+		return StatusUnknown, err
+	}
+
+	switch {
+	case strings.HasPrefix(out, fmt.Sprintf("%s start/running", s.Name)):
+		return StatusRunning, nil
+	case strings.HasPrefix(out, fmt.Sprintf("%s stop/waiting", s.Name)):
+		return StatusStopped, nil
+	default:
+		return StatusUnknown, ErrNotInstalled
+	}
 }
 
 func (s *upstart) Start() error {
@@ -209,7 +245,7 @@ const upstartScript = `# {{.Description}}
 start on filesystem or runlevel [2345]
 stop on runlevel [!2345]
 
-{{if .UserName}}setuid {{.UserName}}{{end}}
+{{if and .UserName .HasSetUIDStanza}}setuid {{.UserName}}{{end}}
 
 respawn
 respawn limit 10 5
@@ -222,5 +258,18 @@ pre-start script
 end script
 
 # Start
-exec {{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}
+script
+	{{if .LogOutput}}
+	stdout_log="/var/log/{{.Name}}.out"
+	stderr_log="/var/log/{{.Name}}.err"
+	{{end}}
+	
+	if [ -f "/etc/sysconfig/{{.Name}}" ]; then
+		set -a
+		source /etc/sysconfig/{{.Name}}
+		set +a
+	fi
+
+	exec {{if and .UserName (not .HasSetUIDStanza)}}sudo -E -u {{.UserName}} {{end}}{{.Path}}{{range .Arguments}} {{.|cmd}}{{end}}{{if .LogOutput}} >> $stdout_log 2>> $stderr_log{{end}}
+end script
 `

--- a/vendor/github.com/kardianos/service/service_windows.go
+++ b/vendor/github.com/kardianos/service/service_windows.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -144,6 +145,10 @@ func (ws *windowsService) String() string {
 	return ws.Name
 }
 
+func (ws *windowsService) Platform() string {
+	return version
+}
+
 func (ws *windowsService) setError(err error) {
 	ws.errSync.Lock()
 	defer ws.errSync.Unlock()
@@ -216,8 +221,10 @@ func (ws *windowsService) Install() error {
 	defer s.Close()
 	err = eventlog.InstallAsEventCreate(ws.Name, eventlog.Error|eventlog.Warning|eventlog.Info)
 	if err != nil {
-		s.Delete()
-		return fmt.Errorf("InstallAsEventCreate() failed: %s", err)
+		if !strings.Contains(err.Error(), "exists") {
+			s.Delete()
+			return fmt.Errorf("SetupEventLogSource() failed: %s", err)
+		}
 	}
 	return nil
 }
@@ -268,11 +275,51 @@ func (ws *windowsService) Run() error {
 
 	sigChan := make(chan os.Signal)
 
-	signal.Notify(sigChan, os.Interrupt, os.Kill)
+	signal.Notify(sigChan, os.Interrupt)
 
 	<-sigChan
 
 	return ws.i.Stop(ws)
+}
+
+func (ws *windowsService) Status() (Status, error) {
+	m, err := mgr.Connect()
+	if err != nil {
+		return StatusUnknown, err
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(ws.Name)
+	if err != nil {
+		if err.Error() == "The specified service does not exist as an installed service." {
+			return StatusUnknown, ErrNotInstalled
+		}
+		return StatusUnknown, err
+	}
+
+	status, err := s.Query()
+	if err != nil {
+		return StatusUnknown, err
+	}
+
+	switch status.State {
+	case svc.StartPending:
+		fallthrough
+	case svc.Running:
+		return StatusRunning, nil
+	case svc.PausePending:
+		fallthrough
+	case svc.Paused:
+		fallthrough
+	case svc.ContinuePending:
+		fallthrough
+	case svc.StopPending:
+		fallthrough
+	case svc.Stopped:
+		return StatusStopped, nil
+	default:
+		return StatusUnknown, fmt.Errorf("unknown status %v", status)
+	}
 }
 
 func (ws *windowsService) Start() error {

--- a/vendor/github.com/kardianos/service/version.go
+++ b/vendor/github.com/kardianos/service/version.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// versionAtMost will return true if the provided version is less than or equal to max
+func versionAtMost(version, max []int) (bool, error) {
+	if comp, err := versionCompare(version, max); err != nil {
+		return false, err
+	} else if comp == 1 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// versionCompare take to versions split into integer arrays and attempts to compare them
+// An error will be returned if there is an array length mismatch.
+// Return values are as follows
+// -1 - v1 is less than v2
+// 0  - v1 is equal to v2
+// 1  - v1 is greater than v2
+func versionCompare(v1, v2 []int) (int, error) {
+	if len(v1) != len(v2) {
+		return 0, errors.New("version length mismatch")
+	}
+
+	for idx, v2S := range v2 {
+		v1S := v1[idx]
+		if v1S > v2S {
+			return 1, nil
+		}
+
+		if v1S < v2S {
+			return -1, nil
+		}
+	}
+	return 0, nil
+}
+
+// parseVersion will parse any integer type version seperated by periods.
+// This does not fully support semver style versions.
+func parseVersion(v string) []int {
+	version := make([]int, 3)
+
+	for idx, vStr := range strings.Split(v, ".") {
+		vS, err := strconv.Atoi(vStr)
+		if err != nil {
+			return nil
+		}
+		version[idx] = vS
+	}
+
+	return version
+}


### PR DESCRIPTION
- on service install (-s) do not exit if hub_url is not set. Instead, show the steps to fix this later.
This allows dpkg -i to install cagent service without credentials and put them later
- on service uninstall (-u) try to stop only running service
- dep/rpm: do not stop pkg remove on service uninstall error