### PR TITLE
Add `ignoreSSLErrors` to webcheck config and respect it.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 cmd/frontman/frontman
+var/ 

--- a/frontman.go
+++ b/frontman.go
@@ -68,6 +68,8 @@ func New(cfg *Config, version string) *Frontman {
 		}
 	}
 
+	fm.initHttpTransport()
+
 	// Add hook to logrus that updates our LastInternalError statistics
 	// whenever an error log is done
 	addErrorHook(fm.Stats)

--- a/types.go
+++ b/types.go
@@ -44,6 +44,7 @@ type WebCheckData struct {
 	SearchHTMLSource    bool    `json:"searchHtmlSource"`
 	ExpectedPattern     string  `json:"expectedPattern,omitempty"`
 	DontFollowRedirects bool    `json:"dontFollowRedirects"`
+	IgnoreSSLErrors     bool    `json:"ignoreSSLErrors,omitempty"`
 	Timeout             float64 `json:"timeout,omitempty"`
 }
 

--- a/webcheck.go
+++ b/webcheck.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -74,9 +75,12 @@ func (fm *Frontman) initHttpTransport() {
 
 // transportWithInsecureSSL creates a default http.Transport,
 // sets the option to skip verification of insecure TLS.
-func (fm *Frontman) transportWithInsecureSSL() *http.Transport {
+func transportWithInsecureSSL(rootCAs *x509.CertPool) *http.Transport {
 	transport := defaultHttpTransport()
-	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true, RootCAs: fm.rootCAs}
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+		RootCAs:            rootCAs,
+	}
 	return transport
 }
 
@@ -110,7 +114,7 @@ func (fm *Frontman) runWebCheck(data WebCheckData) (map[string]interface{}, erro
 
 	var httpTransport *http.Transport
 	if data.IgnoreSSLErrors {
-		httpTransport = fm.transportWithInsecureSSL()
+		httpTransport = transportWithInsecureSSL(fm.rootCAs)
 	} else {
 		httpTransport = fm.httpTransport
 	}

--- a/webcheck.go
+++ b/webcheck.go
@@ -49,8 +49,8 @@ loopDom:
 	return
 }
 
-func (fm *Frontman) initHttpTransport() {
-	fm.httpTransport = &http.Transport{
+func defaultHttpTransport() *http.Transport {
+	return &http.Transport{
 		DisableKeepAlives: true,
 		Proxy:             http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -62,18 +62,22 @@ func (fm *Frontman) initHttpTransport() {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
+}
+
+func (fm *Frontman) initHttpTransport() {
+	fm.httpTransport = defaultHttpTransport()
 
 	if fm.Config.IgnoreSSLErrors {
 		fm.httpTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true, RootCAs: fm.rootCAs}
 	}
 }
 
-// transportWithInsecureSSL creates a copy of the default http.Transport, with
-// option set to skip verification of insecure TLS.
+// transportWithInsecureSSL creates a default http.Transport,
+// sets the option to skip verification of insecure TLS.
 func (fm *Frontman) transportWithInsecureSSL() *http.Transport {
-	transport := *fm.httpTransport
+	transport := defaultHttpTransport()
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true, RootCAs: fm.rootCAs}
-	return &transport
+	return transport
 }
 
 func checkBodyReaderMatchesPattern(reader io.Reader, pattern string, extractTextFromHTML bool) error {


### PR DESCRIPTION
https://tracker.cloudradar.info/issue/DEV-920

There is a missing webcheck option `ignoreSSLErrors`, that should be respected. That means frontman should create new transport if TLS verification must be skipped. I also changed a little bit of http client naming, because I expect it to support more options in the future.
