### PR TITLE
fix: apply default log level from frontman.conf

### DIFF
--- a/frontman.go
+++ b/frontman.go
@@ -71,6 +71,8 @@ func New(cfg *Config, cfgPath, version string) *Frontman {
 		}
 	}
 
+	fm.SetLogLevel(fm.Config.LogLevel)
+
 	fm.initHttpTransport()
 
 	// Add hook to logrus that updates our LastInternalError statistics


### PR DESCRIPTION
Issue: log_level when specified in frontman.conf is never applied to logrus. Only log level given with -v argument to frontman binary is used.

This PR applies the log_level from the config first, and later overrides log level if one is given on the command line.