### PR TITLE
snmp: check any Oid 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,9 +62,9 @@ jobs:
     steps:
       - attach_workspace:
           at: /go/src/github.com/cloudradar-monitoring
-      - run:
-          name: Setup ssh key to access windows signing machine
-          command: echo $SSH_KEY | base64 -d > /tmp/id_ssh && chmod 0600 /tmp/id_ssh
+      - add_ssh_keys:
+          fingerprints:
+            - "b3:b7:b0:59:57:1a:bc:82:6c:3c:91:d6:23:19:f2:08"
       - run: make windows-sign
 
   release-github:

--- a/Makefile
+++ b/Makefile
@@ -42,27 +42,27 @@ goreleaser-snapshot:
 
 windows-sign:
 	# Create remote build dir
-	ssh -i /tmp/id_ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 mkdir -p /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist
+	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 mkdir -p /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist
 	# Copy exe files to Windows VM for bundingling and signing
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/windows_386/frontman.exe  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_386.exe
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/windows_amd64/frontman.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_64.exe
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/windows_386/frontman.exe  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_386.exe
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/windows_amd64/frontman.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_64.exe
 	# Copy other build dependencies
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/build-win.bat hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat
-	ssh -i /tmp/id_ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 chmod +x /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat
-	scp -r -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/pkg-scripts/  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}
-	scp -r -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/resources/  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/example.config.toml hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/example.config.toml
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/example.json hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/example.json
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/LICENSE hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/LICENSE
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/wix.json hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/wix.json
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/build-win.bat hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat
+	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 chmod +x /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat
+	scp -r -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/pkg-scripts/  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}
+	scp -r -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/resources/  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/example.config.toml hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/example.config.toml
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/example.json hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/example.json
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/LICENSE hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/LICENSE
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/wix.json hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/wix.json
 	# Trigger msi creating
-	ssh -i /tmp/id_ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat ${CIRCLE_BUILD_NUM} ${CIRCLE_TAG}
+	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat ${CIRCLE_BUILD_NUM} ${CIRCLE_TAG}
 	# Trigger signing 
-	ssh -i /tmp/id_ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 curl http://localhost:8080/?file=frontman_32.msi
-	ssh -i /tmp/id_ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 curl http://localhost:8080/?file=frontman_64.msi
+	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 curl http://localhost:8080/?file=frontman_32.msi
+	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 curl http://localhost:8080/?file=frontman_64.msi
 	# Copy msi files back to build machine
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_32.msi /go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_386.msi
-	scp -i /tmp/id_ssh -P 24481 -oStrictHostKeyChecking=no hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_64.msi /go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_64.msi
+	scp -P 24481 -oStrictHostKeyChecking=no hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_32.msi /go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_386.msi
+	scp -P 24481 -oStrictHostKeyChecking=no hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_64.msi /go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_64.msi
 	# Add files to Github release
 	github-release upload --user cloudradar-monitoring --repo frontman --tag ${CIRCLE_TAG} --name "frontman_${CIRCLE_TAG}_Windows_386.msi" --file "/go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_386.msi"
 	github-release upload --user cloudradar-monitoring --repo frontman --tag ${CIRCLE_TAG} --name "frontman_${CIRCLE_TAG}_Windows_x86_64.msi" --file "/go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_64.msi"

--- a/frontman.go
+++ b/frontman.go
@@ -33,6 +33,7 @@ type Frontman struct {
 	version string
 
 	previousSNMPBandwidthMeasure []snmpBandwidthMeasure
+	previousSNMPOidDeltaMeasure  []snmpOidDeltaMeasure
 }
 
 func New(cfg *Config, cfgPath, version string) *Frontman {

--- a/handler.go
+++ b/handler.go
@@ -697,15 +697,6 @@ func (fm *Frontman) processInput(input *Input, resultsChan chan<- Result) {
 				return
 			}
 
-			check.Check.ValueType = strings.ToLower(check.Check.ValueType)
-			switch check.Check.ValueType {
-			case "raw", "hex", "delta", "delta_per_sec":
-				break
-			default:
-				logrus.Errorf("snmpCheck: invalid value_type '%s'", check.Check.ValueType)
-				return
-			}
-
 			res := Result{
 				CheckType: "snmpCheck",
 				CheckUUID: check.UUID,

--- a/handler.go
+++ b/handler.go
@@ -697,6 +697,10 @@ func (fm *Frontman) processInput(input *Input, resultsChan chan<- Result) {
 				return
 			}
 
+			if check.Check.ValueType == "" {
+				check.Check.ValueType = "auto"
+			}
+
 			res := Result{
 				CheckType: "snmpCheck",
 				CheckUUID: check.UUID,

--- a/handler.go
+++ b/handler.go
@@ -697,7 +697,8 @@ func (fm *Frontman) processInput(input *Input, resultsChan chan<- Result) {
 				return
 			}
 
-			if check.Check.ValueType == "" {
+			check.Check.ValueType = strings.ToLower(check.Check.ValueType)
+			if check.Check.ValueType == "" || check.Check.ValueType == "raw" {
 				check.Check.ValueType = "auto"
 			}
 

--- a/handler.go
+++ b/handler.go
@@ -702,6 +702,14 @@ func (fm *Frontman) processInput(input *Input, resultsChan chan<- Result) {
 				check.Check.ValueType = "auto"
 			}
 
+			switch check.Check.ValueType {
+			case "auto", "hex", "delta", "delta_per_sec":
+				break
+			default:
+				logrus.Errorf("snmpCheck: invalid value_type '%s'", check.Check.ValueType)
+				return
+			}
+
 			res := Result{
 				CheckType: "snmpCheck",
 				CheckUUID: check.UUID,

--- a/handler.go
+++ b/handler.go
@@ -698,12 +698,8 @@ func (fm *Frontman) processInput(input *Input, resultsChan chan<- Result) {
 			}
 
 			check.Check.ValueType = strings.ToLower(check.Check.ValueType)
-			if check.Check.ValueType == "" || check.Check.ValueType == "raw" {
-				check.Check.ValueType = "auto"
-			}
-
 			switch check.Check.ValueType {
-			case "auto", "hex", "delta", "delta_per_sec":
+			case "raw", "hex", "delta", "delta_per_sec":
 				break
 			default:
 				logrus.Errorf("snmpCheck: invalid value_type '%s'", check.Check.ValueType)

--- a/snmp.go
+++ b/snmp.go
@@ -2,6 +2,7 @@ package frontman
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"strconv"
 	"strings"
@@ -67,19 +68,19 @@ func (fm *Frontman) runSNMPProbe(check *SNMPCheckData) (map[string]interface{}, 
 	}
 	defer params.Conn.Close()
 
-	oids, form, err := presetToOids(check.Preset)
+	oids, form, err := check.presetToOids()
 	if err != nil {
 		return m, err
 	}
 	var packets []gosnmp.SnmpPDU
-	if form == "bulk" {
+	switch form {
+	case "bulk":
 		result, err := params.GetBulk(oids, uint8(len(oids)), maxRepetitions)
 		if err != nil {
 			return m, fmt.Errorf("get bulk err: %v", err)
 		}
 		packets = result.Variables
-	} else {
-		// walk
+	case "walk":
 		for _, oid := range oids {
 			pdus, err := params.BulkWalkAll(oid)
 			if err != nil {
@@ -87,9 +88,15 @@ func (fm *Frontman) runSNMPProbe(check *SNMPCheckData) (map[string]interface{}, 
 			}
 			packets = append(packets, pdus...)
 		}
+	case "single":
+		result, err := params.Get(oids)
+		if err != nil {
+			return m, fmt.Errorf("get err: %v", err)
+		}
+		packets = append(packets, result.Variables...)
 	}
 
-	return fm.prepareSNMPResult(check.Preset, packets)
+	return fm.prepareSNMPResult(check, packets)
 }
 
 type snmpResult struct {
@@ -97,7 +104,7 @@ type snmpResult struct {
 	val interface{}
 }
 
-func (fm *Frontman) prepareSNMPResult(preset string, packets []gosnmp.SnmpPDU) (map[string]interface{}, error) {
+func (fm *Frontman) prepareSNMPResult(check *SNMPCheckData, packets []gosnmp.SnmpPDU) (map[string]interface{}, error) {
 	res := make(map[int][]snmpResult)
 	for _, variable := range packets {
 		if err := oidToError(variable.Name); err != nil {
@@ -109,12 +116,21 @@ func (fm *Frontman) prepareSNMPResult(preset string, packets []gosnmp.SnmpPDU) (
 		prefix, suffix, err := oidToHumanReadable(variable.Name)
 		if err != nil {
 			logrus.Debug(err)
-			continue
+			prefix = variable.Name
 		}
 
 		switch variable.Type {
 		case gosnmp.OctetString:
-			res[suffix] = append(res[suffix], snmpResult{key: prefix, val: string(variable.Value.([]byte))})
+			val := ""
+			if (check.ValueType == "auto" && oidShouldBeHexString(variable.Name)) || check.ValueType == "hex" {
+				// format hex as "99:aa:bb:cc:dd"
+				val = fmt.Sprintf("% x", variable.Value.([]byte))
+				val = strings.ReplaceAll(val, " ", ":")
+			} else {
+				val = string(variable.Value.([]byte))
+			}
+			res[suffix] = append(res[suffix], snmpResult{key: prefix, val: val})
+			log.Println("into", res[suffix])
 
 		case gosnmp.TimeTicks, gosnmp.Integer, gosnmp.Counter32, gosnmp.Gauge32:
 			res[suffix] = append(res[suffix], snmpResult{key: prefix, val: variable.Value})
@@ -123,10 +139,10 @@ func (fm *Frontman) prepareSNMPResult(preset string, packets []gosnmp.SnmpPDU) (
 			res[suffix] = append(res[suffix], snmpResult{key: prefix, val: ""})
 
 		default:
-			logrus.Debugf("SNMP unhandled return type %#v for %s: %d", variable.Type, prefix, gosnmp.ToBigInt(variable.Value))
+			logrus.Debugf("SNMP unhandled return type %#v for %s: %d", variable.Type, prefix, variable.Value)
 		}
 	}
-	return fm.filterSNMPResult(preset, res)
+	return fm.filterSNMPResult(check, res)
 }
 
 const (
@@ -146,9 +162,9 @@ func (kv snmpResult) shouldExcludeInterface() bool {
 }
 
 // filters the snmp results according to preset
-func (fm *Frontman) filterSNMPResult(preset string, res map[int][]snmpResult) (map[string]interface{}, error) {
+func (fm *Frontman) filterSNMPResult(check *SNMPCheckData, res map[int][]snmpResult) (map[string]interface{}, error) {
 	m := make(map[string]interface{})
-	if preset == "bandwidth" {
+	if check.Preset == "bandwidth" {
 		prevMeasures := fm.previousSNMPBandwidthMeasure
 		fm.previousSNMPBandwidthMeasure = nil
 		for idx, iface := range res {
@@ -343,6 +359,16 @@ func ignoreSNMPOid(name string) bool {
 	return false
 }
 
+// returns true if oid should be formatted as a hex string (aa:bb:cc:dd)
+func oidShouldBeHexString(name string) bool {
+	prefix, _, _ := oidToHumanReadable(name)
+	switch prefix {
+	case ".1.3.6.1.2.1.2.2.1.6": // ifPhysAddress
+		return true
+	}
+	return false
+}
+
 // returns human readable error if OID is a error
 func oidToError(name string) (err error) {
 	switch name {
@@ -402,14 +428,15 @@ func oidToHumanReadable(name string) (prefix string, suffix int, err error) {
 		prefix = "ifOutOctets"
 
 	default:
+		prefix = name
 		err = fmt.Errorf("unrecognized OID %s", name)
 	}
 	return
 }
 
 // returns a collection of oids for the given preset
-func presetToOids(preset string) (oids []string, form string, err error) {
-	switch preset {
+func (check *SNMPCheckData) presetToOids() (oids []string, form string, err error) {
+	switch check.Preset {
 	case "basedata":
 		oids = []string{
 			"1.3.6.1.2.1.1.1.0", // STRING: SG350-10 10-Port Gigabit Managed Switch
@@ -431,8 +458,11 @@ func presetToOids(preset string) (oids []string, form string, err error) {
 			".1.3.6.1.2.1.2.2.1.16",    // IF-MIB::ifOutOctets
 		}
 		form = "walk"
+	case "oid":
+		oids = []string{check.Oid}
+		form = "single"
 	default:
-		err = fmt.Errorf("unrecognized preset %s", preset)
+		err = fmt.Errorf("unrecognized preset %s", check.Preset)
 	}
 	return
 }

--- a/snmp.go
+++ b/snmp.go
@@ -61,6 +61,12 @@ func (fm *Frontman) runSNMPCheck(check *SNMPCheck) (map[string]interface{}, erro
 }
 
 func (fm *Frontman) runSNMPProbe(check *SNMPCheckData) (map[string]interface{}, error) {
+
+	check.ValueType = strings.ToLower(check.ValueType)
+	if check.ValueType == "" {
+		check.ValueType = "raw"
+	}
+
 	m := make(map[string]interface{})
 	params, err := buildSNMPParameters(check)
 	if err != nil {
@@ -263,6 +269,8 @@ func (fm *Frontman) filterSNMPOidDeltaResult(check *SNMPCheckData, r snmpResult)
 				break
 			}
 		}
+	} else {
+		logrus.Warnf("snmpCheck: invalid value_type '%s'", check.ValueType)
 	}
 
 	fm.previousSNMPOidDeltaMeasure = append(fm.previousSNMPOidDeltaMeasure, snmpOidDeltaMeasure{

--- a/snmp.go
+++ b/snmp.go
@@ -138,6 +138,9 @@ func (fm *Frontman) prepareSNMPResult(check *SNMPCheckData, packets []gosnmp.Snm
 		case gosnmp.Null:
 			res[suffix] = append(res[suffix], snmpResult{key: prefix, val: ""})
 
+		case gosnmp.NoSuchInstance:
+			return make(map[string]interface{}), fmt.Errorf("no such instance")
+
 		default:
 			logrus.Debugf("SNMP unhandled return type %#v for %s: %d", variable.Type, prefix, variable.Value)
 		}

--- a/snmp.go
+++ b/snmp.go
@@ -207,7 +207,7 @@ func (fm *Frontman) filterSNMPResult(check *SNMPCheckData, res map[int][]snmpRes
 		} else {
 			for idx := range res {
 				for _, r := range res[idx] {
-					m[r.key] = fm.filterSNMPOidDeltaResult(r)
+					m[r.key] = fm.filterSNMPOidDeltaResult(check, r)
 				}
 			}
 		}
@@ -224,11 +224,9 @@ func (fm *Frontman) filterSNMPResult(check *SNMPCheckData, res map[int][]snmpRes
 	return m, nil
 }
 
-func (fm *Frontman) filterSNMPOidDeltaResult(r snmpResult) map[string]interface{} {
-	m := make(map[string]interface{})
-	//m[x.key] = x.val
-
-	m["val"] = r.val.(string)
+func (fm *Frontman) filterSNMPOidDeltaResult(check *SNMPCheckData, r snmpResult) interface{} {
+	var m interface{}
+	m = r.val.(string)
 	return m
 }
 

--- a/snmp_test.go
+++ b/snmp_test.go
@@ -184,7 +184,7 @@ func TestSNMPv2PresetOidHexValue(t *testing.T) {
 	require.Equal(t, true, len(part["value"].(string)) > 0)
 }
 
-func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
+func TestSNMPv2PresetOidDeltaPerSecValue(t *testing.T) {
 	skipSNMP(t)
 
 	delaySeconds := 5.
@@ -194,7 +194,7 @@ func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
 
 	inputConfig := &Input{
 		SNMPChecks: []SNMPCheck{{
-			UUID: "snmp_basedata_v2_oid_delta",
+			UUID: "snmp_basedata_v2_oid_delta_per_sec",
 			Check: SNMPCheckData{
 				Connect:   snmpdIP,
 				Port:      161,
@@ -203,7 +203,7 @@ func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
 				Community: snmpdCommunity,
 				Preset:    "oid",
 				Oid:       ".1.3.6.1.2.1.2.2.1.16.2", //  IF-MIB::ifOutOctets.2
-				ValueType: "delta",
+				ValueType: "delta_per_sec",
 			},
 		}},
 	}
@@ -228,7 +228,7 @@ func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
 
 	part = res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
 	require.Equal(t, true, part["value"].(uint) > 0)
-	require.Equal(t, true, part["delta"].(uint) >= 0)
+	require.Equal(t, true, part["delta_per_sec"].(uint) >= 0)
 }
 
 // test SNMP v2 invalid community against snmpd

--- a/snmp_test.go
+++ b/snmp_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -168,20 +167,19 @@ func TestSNMPv2PresetOid(t *testing.T) {
 				Protocol:  "v2",
 				Community: snmpdCommunity,
 				Preset:    "oid",
-				Oid:       ".1.3.6.1.2.1.2.2.1.20.7",
-				Name:      "ifOutErrors p sec Port 7",
-				ValueType: "delta_per_sec",
-				Unit:      "Eps",
+				Oid:       ".1.3.6.1.2.1.2.2.1.6.2",
+				Name:      "interface mac",
+				ValueType: "hex",
 			},
 		}},
 	}
 	resultsChan := make(chan Result, 100)
 	fm.processInput(inputConfig, resultsChan)
 	res := <-resultsChan
-	require.Equal(t, nil, res.Message)
-	require.Equal(t, 1, res.Measurements["snmpCheck.bandwidth.success"])
 
-	logrus.Println(res)
+	require.Equal(t, nil, res.Message)
+	require.Equal(t, 1, res.Measurements["snmpCheck.oid.success"])
+	require.Equal(t, true, len(res.Measurements[".1.3.6.1.2.1.2.2.1.6.2"].(string)) > 0)
 }
 
 // test SNMP v2 invalid community against snmpd

--- a/snmp_test.go
+++ b/snmp_test.go
@@ -221,8 +221,6 @@ func TestSNMPv2PresetOidDeltaPerSecValue(t *testing.T) {
 	require.Equal(t, nil, res.Message)
 	require.Equal(t, 1, res.Measurements["snmpCheck.oid.success"])
 
-	part := res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
-
 	// do 2nd request and check delta values
 	time.Sleep(time.Duration(delaySeconds) * time.Second)
 
@@ -232,7 +230,7 @@ func TestSNMPv2PresetOidDeltaPerSecValue(t *testing.T) {
 	require.Equal(t, nil, res.Message)
 	require.Equal(t, 1, res.Measurements["snmpCheck.oid.success"])
 
-	part = res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
+	part := res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
 	require.Equal(t, true, part["value"].(float64) >= 0)
 
 	require.Equal(t, ".1.3.6.1.2.1.2.2.1.16.2", part["oid"].(string))
@@ -273,8 +271,6 @@ func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
 	require.Equal(t, nil, res.Message)
 	require.Equal(t, 1, res.Measurements["snmpCheck.oid.success"])
 
-	part := res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
-
 	// do 2nd request and check delta values
 	time.Sleep(time.Duration(delaySeconds) * time.Second)
 
@@ -284,7 +280,7 @@ func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
 	require.Equal(t, nil, res.Message)
 	require.Equal(t, 1, res.Measurements["snmpCheck.oid.success"])
 
-	part = res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
+	part := res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
 	require.Equal(t, true, part["value"].(float64) >= 0)
 
 	require.Equal(t, ".1.3.6.1.2.1.2.2.1.16.2", part["oid"].(string))

--- a/snmp_test.go
+++ b/snmp_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -180,7 +179,9 @@ func TestSNMPv2PresetOidHexValue(t *testing.T) {
 
 	require.Equal(t, nil, res.Message)
 	require.Equal(t, 1, res.Measurements["snmpCheck.oid.success"])
-	require.Equal(t, true, len(res.Measurements[".1.3.6.1.2.1.2.2.1.6.2"].(string)) > 0)
+
+	part := res.Measurements[".1.3.6.1.2.1.2.2.1.6.2"].(map[string]interface{})
+	require.Equal(t, true, len(part["value"].(string)) > 0)
 }
 
 func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
@@ -213,8 +214,10 @@ func TestSNMPv2PresetOidDeltaValue(t *testing.T) {
 	require.Equal(t, nil, res.Message)
 	require.Equal(t, 1, res.Measurements["snmpCheck.oid.success"])
 
-	spew.Dump(res)
-	//require.Equal(t, true, len(res.Measurements[".1.3.6.1.2.1.2.2.1.6.2"].(string)) > 0)
+	part := res.Measurements[".1.3.6.1.2.1.2.2.1.16.2"].(map[string]interface{})
+	require.Equal(t, true, part["value"].(uint) > 0)
+
+	// XXX 2nd run to get a delta
 }
 
 // test SNMP v2 invalid community against snmpd

--- a/types.go
+++ b/types.go
@@ -72,7 +72,7 @@ type SNMPCheckData struct {
 	// values used by "oid" preset
 	Oid       string `json:"oid,omitempty"`
 	Name      string `json:"name,omitempty"`
-	ValueType string `json:"value_type,omitempty"`
+	ValueType string `json:"value_type,omitempty"` // auto (default), hex, XXX
 	Unit      string `json:"unit,omitempty"`
 }
 

--- a/types.go
+++ b/types.go
@@ -68,6 +68,12 @@ type SNMPCheckData struct {
 	AuthenticationPassword string   `json:"authentication_password,omitempty"` // v3
 	PrivacyProtocol        string   `json:"privacy_protocol,omitempty"`        // v3
 	PrivacyPassword        string   `json:"privacy_password,omitempty"`        // v3
+
+	// values used by "oid" preset
+	Oid       string `json:"oid,omitempty"`
+	Name      string `json:"name,omitempty"`
+	ValueType string `json:"value_type,omitempty"`
+	Unit      string `json:"unit,omitempty"`
 }
 
 type Results struct {

--- a/types.go
+++ b/types.go
@@ -72,7 +72,7 @@ type SNMPCheckData struct {
 	// values used by "oid" preset
 	Oid       string `json:"oid,omitempty"`
 	Name      string `json:"name,omitempty"`
-	ValueType string `json:"value_type,omitempty"` // auto (default), hex, XXX
+	ValueType string `json:"value_type,omitempty"` /// auto (default), hex, delta, delta_per_sec
 	Unit      string `json:"unit,omitempty"`
 }
 


### PR DESCRIPTION
extends snmp probe with another preset "oid" used to query a arbitrary oid and return value according to type:

    raw - automatically treat result
    hex - encode result as hex string
    delta_per_sec - calculate a delta per sec value
    delta - calculate a delta between the previous measurement


DEV-1085