### PR TITLE
snmp: work around https://github.com/soniah/gosnmp/issues/196

### DIFF
--- a/snmp.go
+++ b/snmp.go
@@ -79,10 +79,21 @@ func (fm *Frontman) runSNMPProbe(check *SNMPCheckData) (map[string]interface{}, 
 	}
 	defer params.Conn.Close()
 
+	// do a simple snmp probe to make sure we are authenticated (work around issue https://github.com/soniah/gosnmp/issues/196)
+	authRes, err := params.Get([]string{"1.3.6.1.2.1.1.1.0"})
+	if err != nil {
+		return m, fmt.Errorf("get err: %v", err)
+	}
+
+	if err := getErrorFromVariables(authRes.Variables); err != nil {
+		return m, err
+	}
+
 	oids, form, err := check.presetToOids()
 	if err != nil {
 		return m, err
 	}
+
 	var packets []gosnmp.SnmpPDU
 	switch form {
 	case "bulk":
@@ -108,6 +119,16 @@ func (fm *Frontman) runSNMPProbe(check *SNMPCheckData) (map[string]interface{}, 
 	}
 
 	return fm.prepareSNMPResult(check, packets)
+}
+
+// does packets contain errror oid ?
+func getErrorFromVariables(packets []gosnmp.SnmpPDU) error {
+	for _, variable := range packets {
+		if err := oidToError(variable.Name); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type snmpResult struct {

--- a/snmp.go
+++ b/snmp.go
@@ -121,7 +121,7 @@ func (fm *Frontman) runSNMPProbe(check *SNMPCheckData) (map[string]interface{}, 
 	return fm.prepareSNMPResult(check, packets)
 }
 
-// does packets contain errror oid ?
+// getErrorFromVariables returns an error if any of the oid:s in the packets contains a recognized oid error
 func getErrorFromVariables(packets []gosnmp.SnmpPDU) error {
 	for _, variable := range packets {
 		if err := oidToError(variable.Name); err != nil {

--- a/snmp_test.go
+++ b/snmp_test.go
@@ -1,7 +1,7 @@
 package frontman
 
 // In order to run tests, set up snmpd somewhere and
-// $ "FRONTMAN_SNMPD_IP="172.16.72.169" FRONTMAN_SNMPD_COMMUNITY=public go test -v -run TestSNMP"
+// $ FRONTMAN_SNMPD_IP="172.16.72.169" FRONTMAN_SNMPD_COMMUNITY=public go test -v -run TestSNMP
 
 import (
 	"os"
@@ -312,7 +312,7 @@ func TestSNMPv2InvalidCommunity(t *testing.T) {
 	fm.processInput(inputConfig, resultsChan)
 	res := <-resultsChan
 	// NOTE: the only error we get on invalid community name is a timeout
-	require.Equal(t, "get bulk err: Request timeout (after 0 retries)", res.Message)
+	require.Equal(t, "get err: Request timeout (after 0 retries)", res.Message)
 	require.Equal(t, 0, res.Measurements["snmpCheck.basedata.success"])
 }
 
@@ -344,6 +344,10 @@ func TestSNMPv3NoAuthNoPriv(t *testing.T) {
 	fm.processInput(inputConfig, resultsChan)
 	res := <-resultsChan
 	require.Equal(t, nil, res.Message)
+
+	// NOTE: if empty, snmpd is not configured correctly
+	require.Equal(t, true, len(res.Measurements["system.contact"].(string)) > 1)
+
 	require.Equal(t, 1, res.Measurements["snmpCheck.basedata.success"])
 }
 
@@ -474,6 +478,40 @@ func TestSNMPv3AuthPriv(t *testing.T) {
 	require.Equal(t, 1, res.Measurements["snmpCheck.basedata.success"])
 	require.Equal(t, true, len(res.Measurements["system.contact"].(string)) > 1)
 	require.Equal(t, true, len(res.Measurements["system.location"].(string)) > 1)
+}
+
+func TestSNMPv3PresetBandwidthWrongCredentials(t *testing.T) {
+	// this test makes sure that we error out if called with invalid credentials (SNMP v3)
+
+	skipSNMP(t)
+
+	delaySeconds := 1.
+	cfg, _ := HandleAllConfigSetup(DefaultCfgPath)
+	cfg.Sleep = delaySeconds
+	fm := New(cfg, DefaultCfgPath, "1.2.3")
+
+	inputConfig := &Input{
+		SNMPChecks: []SNMPCheck{{
+			UUID: "snmp_basedata_v3_bandwidth_wrong_credentials",
+			Check: SNMPCheckData{
+				Connect:                snmpdIP,
+				Port:                   161,
+				Timeout:                5.0,
+				Protocol:               "v3",
+				Preset:                 "bandwidth",
+				SecurityLevel:          "authNoPriv",
+				Username:               "authOnlyUser",
+				AuthenticationProtocol: "sha",
+				AuthenticationPassword: "wrongpassword",
+			},
+		}},
+	}
+	resultsChan := make(chan Result, 100)
+	fm.processInput(inputConfig, resultsChan)
+	res := <-resultsChan
+
+	require.Equal(t, "wrong digests, possibly wrong password", res.Message)
+	require.Equal(t, 0, res.Measurements["snmpCheck.bandwidth.success"])
 }
 
 func TestOidToHumanReadable(t *testing.T) {


### PR DESCRIPTION
As brought up in private review, some v3 reported success when they had invalid credentials.

This PR works around this issue by first doing a simple oid probe and check its result oid for errors.

This works around an upstream issue described in detail here:
https://github.com/soniah/gosnmp/issues/196