### PR TITLE
Save service state while updating frontman package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
 frontman
 var/ 
+dist/
 *.spk

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -89,6 +89,7 @@ nfpm:
     preinstall: "pkg-scripts/preinstall.sh"
     postinstall: "pkg-scripts/postinstall.sh"
     preremove: "pkg-scripts/preremove.sh"
+
   overrides:
     deb:
       dependencies:
@@ -96,6 +97,9 @@ nfpm:
     rpm:
       dependencies:
       - procps-ng
+      scripts:
+        postinstall: "pkg-scripts/postinstall-rpm.sh"
+        preremove: "pkg-scripts/preremove-rpm.sh"
 
 release:
   github:

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -45,11 +45,12 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:46da7427e7bed7f7cbf5ff8df4c8f588a5e680dc0e0b4fe524fd5b68c846b47f"
+  digest = "1:90ed64fe94fa51071158465da85b56eaf644e5d9f5815faf1eead13c242d7de2"
   name = "github.com/kardianos/service"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "0e5bec1b9eec14f9070a6f49ad7e0242f1545d66"
+  revision = "c1c4306577988c5b299c64af2f0ccea15d1f7d54"
+  source = "github.com/cloudradar-monitoring/service"
 
 [[projects]]
   digest = "1:58999a98719fddbac6303cb17e8d85b945f60b72f48e3a2df6b950b97fa926f1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -17,7 +17,8 @@
 
 [[constraint]]
   name = "github.com/kardianos/service"
-  revision = "0e5bec1b9eec14f9070a6f49ad7e0242f1545d66"
+  revision = "c1c4306577988c5b299c64af2f0ccea15d1f7d54"
+  source = "github.com/cloudradar-monitoring/service"
 
 [[constraint]]
   name = "github.com/sparrc/go-ping"

--- a/cmd/frontman/service.go
+++ b/cmd/frontman/service.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/kardianos/service"
+	"github.com/sirupsen/logrus"
+)
+
+func tryStartService(s service.Service) {
+	logrus.Info("Starting service...")
+	err := s.Start()
+	if err != nil {
+		logrus.WithError(err).Warningf("Frontman service(%s) startup failed", s.Platform())
+	}
+}
+
+func tryInstallService(s service.Service, assumeYesPtr *bool) {
+	const maxAttempts = 3
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		err := s.Install()
+		// Check error case where the service already exists
+		if err != nil && strings.Contains(err.Error(), "already exists") {
+			if attempt == maxAttempts {
+				logrus.Fatalf("Giving up after %d attempts", maxAttempts)
+			}
+
+			var osSpecificNote string
+			if runtime.GOOS == "windows" {
+				osSpecificNote = " Windows Services Manager application must be closed before proceeding!"
+			}
+
+			fmt.Printf("Frontman service(%s) already installed: %s\n", s.Platform(), err.Error())
+			if *assumeYesPtr || askForConfirmation("Do you want to overwrite it?"+osSpecificNote) {
+				logrus.Info("Trying to override old service unit...")
+				err = s.Stop()
+				if err != nil {
+					logrus.WithError(err).Warnln("Failed to stop the service")
+				}
+
+				// lets try to uninstall despite of this error
+				err := s.Uninstall()
+				if err != nil {
+					logrus.WithError(err).Fatalln("Failed to uninstall the service")
+				}
+			}
+		} else if err != nil {
+			logrus.WithError(err).Fatalf("Frontman service(%s) installation failed", s.Platform())
+		} else {
+			logrus.Infof("Frontman service(%s) has been installed.", s.Platform())
+			break
+		}
+	}
+}
+
+func tryUpgradeServiceUnit(s service.Service) {
+	_, err := s.Status()
+	if err == service.ErrNotInstalled {
+		logrus.Error("Can't upgrade service: service is not installed")
+		return
+	}
+
+	configureServiceEnabledState(s)
+
+	err = s.Stop()
+	if err != nil {
+		logrus.WithError(err).Warnln("Failed to stop the service")
+	}
+
+	err = s.Uninstall()
+	if err != nil {
+		logrus.WithError(err).Fatalln("Failed to uninstall the service")
+	}
+
+	err = s.Install()
+	if err != nil {
+		logrus.WithError(err).Fatalf("Frontman service(%s) unit upgrade failed", s.Platform())
+	}
+
+	logrus.Infof("Frontman service(%s) unit has been upgraded.", s.Platform())
+}

--- a/cmd/frontman/service_notwindows.go
+++ b/cmd/frontman/service_notwindows.go
@@ -1,0 +1,90 @@
+// +build !windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"os/user"
+	"path/filepath"
+	"strconv"
+
+	"github.com/kardianos/service"
+	"github.com/sirupsen/logrus"
+
+	"github.com/cloudradar-monitoring/frontman"
+)
+
+func updateServiceConfig(ca *frontman.Frontman, userName string) {
+	u, err := user.Lookup(userName)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"user": userName,
+		}).WithError(err).Fatalln("Failed to find the user")
+	}
+	svcConfig.UserName = userName
+	// we need to chown log file with user who will run service
+	// because installer can be run under root so the log file will be also created under root
+	err = chownFile(ca.Config.LogFile, u)
+	if err != nil {
+		logrus.WithFields(logrus.Fields{
+			"user": userName,
+		}).WithError(err).Warnln("Failed to chown log file")
+	}
+}
+
+func chownFile(filePath string, u *user.User) error {
+	uid, err := strconv.Atoi(u.Uid)
+	if err != nil {
+		return fmt.Errorf("Chown files: error converting UID(%s) to int", u.Uid)
+	}
+
+	gid, err := strconv.Atoi(u.Gid)
+	if err != nil {
+		return fmt.Errorf("Chown files: error converting GID(%s) to int", u.Gid)
+	}
+
+	return os.Chown(filePath, uid, gid)
+}
+
+func configureServiceEnabledState(s service.Service) {
+	serviceMgrName := s.Platform()
+	isServiceAlreadyEnabled := true
+	if serviceMgrName == "linux-systemd" {
+		isServiceAlreadyEnabled = checkIfSystemdServiceEnabled(svcConfig.Name)
+	}
+	if serviceMgrName == "unix-systemv" {
+		isServiceAlreadyEnabled = checkIfSysvServiceEnabled(svcConfig.Name)
+	}
+
+	if svcConfig.Option == nil {
+		svcConfig.Option = service.KeyValue{}
+	}
+
+	svcConfig.Option["Enabled"] = isServiceAlreadyEnabled
+}
+
+func checkIfSystemdServiceEnabled(serviceName string) bool {
+	cmd := exec.Command("systemctl", "is-enabled", serviceName+".service")
+	err := cmd.Run()
+	return err == nil
+}
+
+func checkIfSysvServiceEnabled(serviceName string) bool {
+	configPath := "/etc/init.d/" + serviceName
+	runLevels := []string{"1", "2", "3", "4", "5"}
+
+	// search config symlinks in each runlevel folder:
+	for _, level := range runLevels {
+		dirFiles, _ := filepath.Glob("/etc/rc" + level + ".d/*" + serviceName)
+		for _, file := range dirFiles {
+			linkSrc, _ := filepath.EvalSymlinks(file)
+			if absLinkPath, _ := filepath.Abs(linkSrc); absLinkPath == configPath {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/cmd/frontman/service_windows.go
+++ b/cmd/frontman/service_windows.go
@@ -1,0 +1,17 @@
+// +build windows
+
+package main
+
+import (
+	"github.com/kardianos/service"
+
+	"github.com/cloudradar-monitoring/frontman"
+)
+
+func updateServiceConfig(ca *frontman.Frontman, username string) {
+	// nothing to do
+}
+
+func configureServiceEnabledState(s service.Service) {
+	// nothing to do
+}

--- a/pkg-scripts/postinstall-rpm.sh
+++ b/pkg-scripts/postinstall-rpm.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+CONFIG_PATH=/etc/frontman/frontman.conf
+
+# Install the first time:	1
+# Upgrade: 2 or higher (depending on the number of versions installed)
+versionsCount=$1
+
+if [ ${versionsCount} == 1 ]; then # fresh install
+    /usr/bin/frontman -y -s frontman -c ${CONFIG_PATH}
+else # package update
+    serviceStatus=`/usr/bin/frontman -y -service_status -c ${CONFIG_PATH}`
+    echo "current service status: $serviceStatus."
+
+    if [ "$serviceStatus" != stopped ]; then
+        echo "stopping service..."
+        /usr/bin/frontman -service_stop || true
+    fi
+
+    echo "upgrading service unit... "
+    /usr/bin/frontman -y -s frontman -service_upgrade -c ${CONFIG_PATH}
+
+    # restart only if it was active before
+    if [ "$serviceStatus" != stopped ]; then
+        echo "restarting service... "
+        /usr/bin/frontman -y -service_restart -c ${CONFIG_PATH}
+    fi
+fi
+
+/usr/bin/frontman -t || true

--- a/pkg-scripts/postinstall.sh
+++ b/pkg-scripts/postinstall.sh
@@ -1,3 +1,29 @@
 #!/bin/sh
-/usr/bin/frontman -s frontman -c /etc/frontman/frontman.conf
+
+CONFIG_PATH=/etc/frontman/frontman.conf
+
+if [ "$1" = configure ]; then
+    # $2 contains previous version number
+    if [ -z "$2" ]; then # fresh install
+        /usr/bin/frontman -y -s frontman -c ${CONFIG_PATH}
+    else # package update
+        serviceStatus=`/usr/bin/frontman -y -service_status -c ${CONFIG_PATH}`
+        echo "current service status: $serviceStatus."
+
+        if [ "$serviceStatus" != stopped ]; then
+            echo "stopping service..."
+            /usr/bin/frontman -service_stop || true
+        fi
+
+        echo "upgrading service unit... "
+        /usr/bin/frontman -y -s frontman -service_upgrade -c ${CONFIG_PATH}
+
+        # restart only if it was active before
+        if [ "$serviceStatus" != stopped ]; then
+            echo "restarting service... "
+            /usr/bin/frontman -y -service_restart -c ${CONFIG_PATH}
+        fi
+    fi
+fi
+
 /usr/bin/frontman -t || true

--- a/pkg-scripts/preremove-rpm.sh
+++ b/pkg-scripts/preremove-rpm.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Removing during upgrade:         1 or higher
+# Remove last version of package:  0
+versionsCount=$1
+
+# we need to uninstall service only if we are removing the last packages
+if [ ${versionsCount} -lt 1 ]; then
+  /usr/bin/frontman -u || true
+fi

--- a/pkg-scripts/preremove.sh
+++ b/pkg-scripts/preremove.sh
@@ -1,2 +1,17 @@
 #!/bin/sh
-/usr/bin/frontman -u || true
+
+case "$1" in
+    remove)
+        # remove service only when removing package (not update)
+        /usr/bin/frontman -u
+        ;;
+    upgrade)
+        # do not stop service on package upgrade because it will be restarted by new package' postinst script
+        ;;
+    *)
+        echo "stopping service..."
+        /usr/bin/frontman -service_stop || true
+        ;;
+esac
+
+exit 0

--- a/vendor/github.com/kardianos/service/service.go
+++ b/vendor/github.com/kardianos/service/service.go
@@ -77,10 +77,15 @@ const (
 	optionSessionCreateDefault = false
 	optionLogOutput            = "LogOutput"
 	optionLogOutputDefault     = false
+	optionEnabled              = "Enabled"
+	optionEnabledDefault       = true
 
 	optionRunWait      = "RunWait"
 	optionReloadSignal = "ReloadSignal"
 	optionPIDFile      = "PIDFile"
+	optionRestart      = "Restart"
+
+	optionSuccessExitStatus = "SuccessExitStatus"
 
 	optionSystemdScript = "SystemdScript"
 	optionSysvScript    = "SysvScript"
@@ -139,6 +144,11 @@ type Config struct {
 	//    - ReloadSignal  string () [USR1, ...]     - Signal to send on reaload.
 	//    - PIDFile       string () [/run/prog.pid] - Location of the PID file.
 	//    - LogOutput     bool   (false)            - Redirect StdErr & StdOut to files.
+	//    - Restart       string (always)           - How shall service be restarted.
+	//    - SuccessExitStatus string ()             - The list of exit status that shall be considered as successful,
+	//                                                in addition to the default ones.
+	//  * SysV and Systemd only
+	//    - Enabled       bool   (true) - Enable service just after installation.
 	Option KeyValue
 }
 

--- a/vendor/github.com/kardianos/service/service_systemd_linux.go
+++ b/vendor/github.com/kardianos/service/service_systemd_linux.go
@@ -5,6 +5,7 @@
 package service
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -19,6 +20,21 @@ import (
 func isSystemd() bool {
 	if _, err := os.Stat("/run/systemd/system"); err == nil {
 		return true
+	}
+	if _, err := os.Stat("/proc/1/comm"); err == nil {
+		filerc, err := os.Open("/proc/1/comm")
+		if err != nil {
+			return false
+		}
+		defer filerc.Close()
+
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(filerc)
+		contents := buf.String()
+
+		if strings.Trim(contents, " \r\n") == "systemd" {
+			return true
+		}
 	}
 	return false
 }
@@ -133,6 +149,8 @@ func (s *systemd) Install() error {
 		HasOutputFileSupport bool
 		ReloadSignal         string
 		PIDFile              string
+		Restart              string
+		SuccessExitStatus    string
 		LogOutput            bool
 	}{
 		s.Config,
@@ -140,6 +158,8 @@ func (s *systemd) Install() error {
 		s.hasOutputFileSupport(),
 		s.Option.string(optionReloadSignal, ""),
 		s.Option.string(optionPIDFile, ""),
+		s.Option.string(optionRestart, "always"),
+		s.Option.string(optionSuccessExitStatus, ""),
 		s.Option.bool(optionLogOutput, optionLogOutputDefault),
 	}
 
@@ -148,10 +168,15 @@ func (s *systemd) Install() error {
 		return err
 	}
 
-	err = run("systemctl", "enable", s.Name+".service")
+	enableCmd := "enable"
+	if !s.Option.bool(optionEnabled, optionEnabledDefault) {
+		enableCmd = "disable"
+	}
+	err = run("systemctl", enableCmd, s.Name+".service")
 	if err != nil {
 		return err
 	}
+
 	return run("systemctl", "daemon-reload")
 }
 
@@ -201,6 +226,31 @@ func (s *systemd) Status() (Status, error) {
 		return StatusUnknown, err
 	}
 
+	result, err := resolveStatusFromSystemctlOutput(out)
+	if err == ErrNotInstalled {
+		// fallback to other means of identifying state:
+		exitCode, out, err = runWithOutput("systemctl", "show", "--property=ActiveState", s.Name)
+		if err != nil {
+			return StatusUnknown, err
+		}
+
+		outputLines := strings.Split(strings.TrimSpace(out), "\n")
+		if len(outputLines) != 1 {
+			return StatusUnknown, fmt.Errorf("unexpected output from 'systemctl show' command: %s", out)
+		}
+
+		activeStateLine := strings.Split(outputLines[0], "=")
+		if len(activeStateLine) != 2 {
+			return StatusUnknown, fmt.Errorf("unexpected output from 'systemctl show' command: %s", activeStateLine)
+		}
+
+		return resolveStatusFromSystemctlOutput(activeStateLine[1])
+	}
+
+	return result, err
+}
+
+func resolveStatusFromSystemctlOutput(out string) (Status, error) {
 	switch {
 	case strings.HasPrefix(out, "active"):
 		return StatusRunning, nil
@@ -228,9 +278,8 @@ func (s *systemd) Restart() error {
 const systemdScript = `[Unit]
 Description={{.Description}}
 ConditionFileIsExecutable={{.Path|cmdEscape}}
-{{range .Dependencies}}
-{{.}}
-{{end}}
+{{range $i, $dep := .Dependencies}} 
+{{$dep}} {{end}}
 
 [Service]
 StartLimitInterval=5
@@ -245,7 +294,8 @@ ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 StandardOutput=file:/var/log/{{.Name}}.out
 StandardError=file:/var/log/{{.Name}}.err
 {{- end}}
-Restart=always
+{{if .Restart}}Restart={{.Restart}}{{end}}
+{{if .SuccessExitStatus}}SuccessExitStatus={{.SuccessExitStatus}}{{end}}
 RestartSec=120
 EnvironmentFile=-/etc/sysconfig/{{.Name}}
 

--- a/vendor/github.com/kardianos/service/service_sysv_linux.go
+++ b/vendor/github.com/kardianos/service/service_sysv_linux.go
@@ -100,14 +100,22 @@ func (s *sysv) Install() error {
 	if err = os.Chmod(confPath, 0755); err != nil {
 		return err
 	}
+
+	enableService := s.Option.bool(optionEnabled, optionEnabledDefault)
 	for _, i := range [...]string{"2", "3", "4", "5"} {
-		if err = os.Symlink(confPath, "/etc/rc"+i+".d/S50"+s.Name); err != nil {
-			continue
+		linkPath := "/etc/rc"+i+".d/S50"+s.Name
+		if enableService {
+			_ = os.Symlink(confPath, linkPath)
+		} else {
+			_ = os.Remove(linkPath)
 		}
 	}
 	for _, i := range [...]string{"0", "1", "6"} {
-		if err = os.Symlink(confPath, "/etc/rc"+i+".d/K02"+s.Name); err != nil {
-			continue
+		linkPath := "/etc/rc"+i+".d/K02"+s.Name
+		if enableService {
+			_ = os.Symlink(confPath, linkPath)
+		} else {
+			_ = os.Remove(linkPath)
 		}
 	}
 


### PR DESCRIPTION
This is the port of cagent PR [#146](https://github.com/cloudradar-monitoring/cagent/pull/162)

Service will not started during update if it was stopped before update.
Service will not enabled during Update if it was disabled before update.

- updated dependencies to use our fork of kardianos/service
- fix hanging when trying to stop already stopped service
- new cmd line option added: -service_upgrade to update service unit file
- new cmd line option added: -y to assume Yes to all prompts to run non-interactively
- new cmd line options added to control service state: -service_stop, -service_start, -service_restart, -service_status
- refactored the main.go file - some functions were moved to separate files

Some helpful links on deb and rpm maintainer scripts:
https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html
https://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch09s04s05.html