### PR TITLE
Webcheck fixes

### DIFF
--- a/webcheck.go
+++ b/webcheck.go
@@ -232,10 +232,10 @@ func (fm *Frontman) newClientWithOptions(transport *http.Transport, maxRedirects
 		}
 
 		if maxRedirects <= 0 {
-			logrus.Println("CheckRedirect: redirects are not allowed")
+			logrus.Println("redirects are not allowed")
 			return http.ErrUseLastResponse
 		} else if len(via) > maxRedirects {
-			logrus.Printf("CheckRedirect: too many(>%d) redirects", maxRedirects)
+			logrus.Printf("too many(>%d) redirects", maxRedirects)
 			return http.ErrUseLastResponse
 		}
 		return nil

--- a/webcheck.go
+++ b/webcheck.go
@@ -223,6 +223,14 @@ func (fm *Frontman) newClientWithOptions(transport *http.Transport, maxRedirects
 	client := &http.Client{Transport: transport}
 
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// copies headers from previous request (go strips Authorization header on redirects)
+		lastRequest := via[len(via)-1]
+		for attr, val := range lastRequest.Header {
+			if _, ok := req.Header[attr]; !ok {
+				req.Header[attr] = val
+			}
+		}
+
 		if maxRedirects <= 0 {
 			logrus.Println("CheckRedirect: redirects are not allowed")
 			return http.ErrUseLastResponse


### PR DESCRIPTION
Some additional fixes  for  DEV-1113

- Certain http headers is stripped by golang (such as Authorization) on redirects, so we copy all headers from previous request
- The wrapping of http.Client made CheckRedirect callback not trigger
- The use of httptrace just to measure request time is overkill
