### PR TITLE
spk: force build static binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2
 docker_job_setup: &docker_job
   docker:
-    - image: cloudradario/go-build:0.0.14
+    - image: cloudradario/go-build:0.0.15
   working_directory: /go/src/github.com/cloudradar-monitoring/frontman
 
 attach_workspace: &workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,17 @@
 ---
 version: 2
+docker_job_setup: &docker_job
+  docker:
+    - image: cloudradario/go-build:0.0.14
+  working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+
+attach_workspace: &workspace
+  attach_workspace:
+    at: /go/src/github.com/cloudradar-monitoring
+
 jobs:
   get-source:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
       - checkout
       - persist_to_workspace:
@@ -13,30 +20,21 @@ jobs:
             - frontman
 
   test:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
-      - attach_workspace:
-          at: /go/src/github.com/cloudradar-monitoring
+      - <<: *workspace
       - run: make test
 
   test-goreleaser:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
-      - attach_workspace:
-          at: /go/src/github.com/cloudradar-monitoring
+      - <<: *workspace
       - run: make goreleaser-snapshot
 
   build-goreleaser:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
-      - attach_workspace:
-          at: /go/src/github.com/cloudradar-monitoring
+      - <<: *workspace
       - run: make goreleaser-rm-dist
       - persist_to_workspace:
           root: /go/src/github.com/cloudradar-monitoring
@@ -44,33 +42,25 @@ jobs:
             - frontman
 
   build-docker:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
-      - attach_workspace:
-          at: /go/src/github.com/cloudradar-monitoring
+      - <<: *workspace
       - setup_remote_docker
       - run: docker login --username ${DOCKERHUB_USER} --password ${DOCKERHUB_PASS}
       - run: docker build --build-arg FRONTMAN_VERSION=${CIRCLE_TAG} -t cloudradario/frontman:${CIRCLE_TAG} .
       - run: docker push cloudradario/frontman:${CIRCLE_TAG}
 
   build-sign-msi:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
-      - attach_workspace:
-          at: /go/src/github.com/cloudradar-monitoring
+      - <<: *workspace
       - add_ssh_keys:
           fingerprints:
             - "b3:b7:b0:59:57:1a:bc:82:6c:3c:91:d6:23:19:f2:08"
       - run: make windows-sign
 
   release-github:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
       - run:
           name: Fetch release changelog so we can preserve it when releasing
@@ -91,12 +81,9 @@ jobs:
           when: on_fail
 
   build-synology-spk:
-    docker:
-      - image: cloudradario/go-build:0.0.11
-    working_directory: /go/src/github.com/cloudradar-monitoring/frontman
+    <<: *docker_job
     steps:
-      - attach_workspace:
-          at: /go/src/github.com/cloudradar-monitoring
+      - <<: *workspace
       - run:
           name: Build Synology packages
           command: make synology-spk

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ builds:
   - arm
   - arm64
   goarm:
+  - 5
+  - 6
   - 7
   # List of combinations of GOOS + GOARCH + GOARM to ignore.
   ignore:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,8 +53,7 @@ changelog:
     - '^docs:'
     - '^test:'
 nfpm:
-  # Default: `{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}`
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
   vendor: cloudradar GmbH
   maintainer: Roman Khafizianov <frontman@cloudradar.io>

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ windows-sign:
 	# Create remote build dir
 	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 mkdir -p /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist
 	# Copy exe files to Windows VM for bundingling and signing
-	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/windows_386/frontman.exe  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_386.exe
-	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/windows_amd64/frontman.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_64.exe
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_windows_386/frontman.exe  hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_386.exe
+	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/dist/frontman_windows_amd64/frontman.exe hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/dist/frontman_64.exe
 	# Copy other build dependencies
 	scp -P 24481 -oStrictHostKeyChecking=no /go/src/github.com/cloudradar-monitoring/frontman/build-win.bat hero@144.76.9.139:/cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat
 	ssh -p 24481 -oStrictHostKeyChecking=no hero@144.76.9.139 chmod +x /cygdrive/C/Users/hero/ci/frontman_ci/build_msi/${CIRCLE_BUILD_NUM}/build-win.bat

--- a/synology-spk/create_spk.sh
+++ b/synology-spk/create_spk.sh
@@ -24,6 +24,7 @@ mv frontman.spk ../frontman-armv7.spk
 rm -f package.tgz
 cd ..
 
+git diff
 git checkout 2_create_project/INFO
 
 
@@ -45,6 +46,7 @@ mv frontman.spk ../frontman-armv8.spk
 rm -f package.tgz
 cd ..
 
+git diff
 git checkout 2_create_project/INFO
 
 
@@ -66,4 +68,5 @@ mv frontman.spk ../frontman-amd64.spk
 rm -f package.tgz
 cd ..
 
+git diff
 git checkout 2_create_project/INFO

--- a/synology-spk/create_spk.sh
+++ b/synology-spk/create_spk.sh
@@ -12,7 +12,7 @@ rm 2_create_project/INFO.bak
 sed -i.bak "s/{PKG_ARCH}/noarch/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 
-GOOS=linux GOARCH=arm GOARM=7 go build github.com/cloudradar-monitoring/frontman/cmd/frontman/...
+CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build github.com/cloudradar-monitoring/frontman/cmd/frontman/...
 mv -f frontman 1_create_package/frontman
 
 cd 1_create_package
@@ -34,7 +34,7 @@ rm 2_create_project/INFO.bak
 sed -i.bak "s/{PKG_ARCH}/noarch/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 
-GOOS=linux GOARCH=arm64 go build github.com/cloudradar-monitoring/frontman/cmd/frontman/...
+CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build github.com/cloudradar-monitoring/frontman/cmd/frontman/...
 mv -f frontman 1_create_package/frontman
 
 cd 1_create_package
@@ -56,7 +56,7 @@ rm 2_create_project/INFO.bak
 sed -i.bak "s/{PKG_ARCH}/x86_64 cedarview bromolow broadwell/g" 2_create_project/INFO
 rm 2_create_project/INFO.bak
 
-GOOS=linux GOARCH=amd64 go build github.com/cloudradar-monitoring/frontman/cmd/frontman/...
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build github.com/cloudradar-monitoring/frontman/cmd/frontman/...
 mv -f frontman 1_create_package/frontman
 
 cd 1_create_package

--- a/synology-spk/create_spk.sh
+++ b/synology-spk/create_spk.sh
@@ -27,6 +27,7 @@ cd ..
 git diff
 git checkout 2_create_project/INFO
 
+# IMPORTANT: CGO_ENABLED=0 is used to force binaries to be statically linked
 
 # ARMv8
 sed -i.bak "s/{PKG_VERSION}/$1/g" 2_create_project/INFO


### PR DESCRIPTION
Turns out circleci produced shared binaries which did not work in Synology DSM.

Using CGO_ENABLED=0 we force the binary to be statically linked.

Also update gobuild and some circleci tweaks

Follow-up to DEV-1117