### PR TITLE
snmp: fix rounding error in time calculation

### DIFF
--- a/snmp.go
+++ b/snmp.go
@@ -369,11 +369,7 @@ func (fm *Frontman) filterSNMPBandwidthResult(idx int, iface []snmpResult, prevM
 	// calculate delta from previous measure
 	for _, measure := range prevMeasures {
 		if measure.name == ifName {
-			delaySeconds := float64(time.Since(measure.timestamp) / time.Second)
-			if delaySeconds <= 0 {
-				logrus.Warnf("snmp bandwidth: negative timestamp: %v, now: %v", measure.timestamp, time.Now())
-				continue
-			}
+			delaySeconds := float64(time.Since(measure.timestamp)) / float64(time.Second)
 			inDelta := float64(delta(measure.ifInOctets, ifIn))
 			outDelta := float64(delta(measure.ifOutOctets, ifOut))
 			m["ifIn_Bps"] = math.Round(inDelta / delaySeconds)
@@ -433,7 +429,7 @@ func (fm *Frontman) filterSNMPPorterrorsResult(idx int, iface []snmpResult, prev
 	// calculate delta from previous measure
 	for _, measure := range prevMeasures {
 		if measure.name == ifName {
-			delaySeconds := float64(time.Since(measure.timestamp) / time.Second)
+			delaySeconds := float64(time.Since(measure.timestamp)) / float64(time.Second)
 			inErrorsDelta := float64(delta(measure.ifInErrors, ifInErrors))
 			outErrorsDelta := float64(delta(measure.ifOutErrors, ifOutErrors))
 			m["ifInErrors_delta"] = uint(math.Round(inErrorsDelta / delaySeconds))


### PR DESCRIPTION
The previous calculation lost precision due to integer division.

This would trigger the following diagnostics put in place to debug this issue

```
time="2019-07-08T12:23:32Z" level=warning msg="snmp bandwidth: negative timestamp: 2019-07-08 12:23:32.404649721 +0000 UTC m=+249.476742901, now: 2019-07-08 12:23:32.442744635 +0000 UTC m=+249.514837815"
```