### PR TITLE
interval mode: also sleep when no checks is performend

### DIFF
--- a/sendermode.go
+++ b/sendermode.go
@@ -181,11 +181,12 @@ func (fm *Frontman) sendResultsChanToHubWithInterval(resultsChan chan Result) er
 			err = fmt.Errorf("postResultsToHub error: %s", err.Error())
 		}
 
+		// sleep until interval has passed in full
+		if timeLeft > 0 {
+			time.Sleep(timeLeft)
+		}
+
 		if shouldReturn {
-			// sleep until interval has passed in full
-			if timeLeft > 0 {
-				time.Sleep(timeLeft)
-			}
 			return err
 		}
 


### PR DESCRIPTION
Currently, frontman spams the hub nonstop if it is run with no checks.
This PR fixes behavior to sleep in defined interval.