### PR TITLE
Add meaningful description of installed cagent service

### DIFF
--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -32,8 +32,8 @@ var (
 
 var svcConfig = &service.Config{
 	Name:        "frontman",
-	DisplayName: "Frontman",
-	Description: "Monitoring proxy for agentless monitoring of subnets",
+	DisplayName: "CloudRadar Frontman",
+	Description: "A versatile open source monitoring agent developed by cloudradar.io. It monitors your local intranet.",
 }
 
 func main() {

--- a/pkg-scripts/msi-templates/product.wxs
+++ b/pkg-scripts/msi-templates/product.wxs
@@ -49,7 +49,17 @@
                 <RemoveFolder Id="CleanApplicationFolders" Directory="ApplicationProgramsFolder" On="uninstall" />
                   {{range $i, $e := .Files.Items}}
                      {{if eq $i 0}}
-                         <ServiceInstall Id="ServiceInstaller" Name="Frontman" Type="ownProcess" Vital="yes" DisplayName="Frontman" Description="Frontman" Start="auto" Account="LocalSystem" ErrorControl="normal" Arguments=" /start frontman" Interactive="no" />
+                         <ServiceInstall Id="ServiceInstaller"
+                            Name="Frontman"
+                            Type="ownProcess"
+                            Vital="yes"
+                            DisplayName="CloudRadar Frontman"
+                            Description="A versatile open source monitoring agent developed by cloudradar.io. It monitors your local intranet."
+                            Start="auto"
+                            Account="LocalSystem"
+                            ErrorControl="normal"
+                            Arguments=" /start frontman"
+                            Interactive="no" />
                          <ServiceControl Id="StartService" Name="Frontman" Stop="both" Start="install" Remove="uninstall" Wait="yes" >
                             <ServiceArgument />
                         </ServiceControl>


### PR DESCRIPTION
Shown in "Services" on Windows and in the output of "service cagent status" command on Linux systems.