### PR TITLE
gzip mode: log errors from gzip writer Close()

### DIFF
--- a/sendermode.go
+++ b/sendermode.go
@@ -56,8 +56,11 @@ func (fm *Frontman) postResultsToHub(results []Result) error {
 	if fm.Config.HubGzip {
 		var buffer bytes.Buffer
 		zw := gzip.NewWriter(&buffer)
-		defer zw.Close()
 		if _, err := zw.Write(b); err != nil {
+			_ = zw.Close()
+			return err
+		}
+		if err := zw.Close(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Issues crop up recently with gzip writer mode.

The only change recently is this:

https://github.com/cloudradar-monitoring/frontman/commit/13c5fcd06f6fb0d66c553eeb0d2fd7f119740889#diff-7014c3e6a78db162cf67691c27240f99

This PR reworks the code to avoid using defer and propagate error from writer.Close()

DEV-1201