### PR TITLE
Make procps package dependency not required but recommended

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,9 +71,9 @@ nfpm:
   - deb
   - rpm
 
-  # Recommend to install root SSL certificates
   recommends:
   - ca-certificates
+  - procps
 
   # Override default /usr/local/bin destination for binaries
   bindir: /usr/bin
@@ -97,11 +97,9 @@ nfpm:
     preremove: "pkg-scripts/preremove.sh"
 
   overrides:
-    deb:
-      dependencies:
-      - procps
     rpm:
-      dependencies:
+      recommends:
+      - ca-certificates
       - procps-ng
       scripts:
         postinstall: "pkg-scripts/postinstall-rpm.sh"


### PR DESCRIPTION
procps-ng package is not available for CentOS 6 making RPM-installation impossible.
Also, there is no direct use of tools provided by this package, so we should not make it hard dependency

DEV-1225
> Well, I made a full search across the codebase and it looks like removing the dependency clearly will not have any bad consequences.
There are some usages of 'sysctl' and 'kill' commands by DEB and RPM packages, but any system that has DEB or RPM support will definitely have these commands available.
