### PR TITLE
Close file before removing it from the system

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -88,6 +88,9 @@ ignore_ssl_errors = true
 		tmpFile, err := ioutil.TempFile("", "")
 		assert.Nil(t, err)
 		configFilePath := tmpFile.Name()
+		err = tmpFile.Close()
+		assert.Nil(t, err)
+
 		err = os.Remove(tmpFile.Name())
 		assert.Nil(t, err)
 


### PR DESCRIPTION
There was a test failing on Windows because of calling os.Remove on the file open for writing