### PR TITLE
Don't reuse http.Transport object as it could lead to reusing the same TLS cached certificates internally

### DIFF
--- a/frontman.go
+++ b/frontman.go
@@ -22,7 +22,6 @@ type Frontman struct {
 	Stats                       *stats.FrontmanStats
 	HealthCheckPassedPreviously bool
 
-	httpTransport *http.Transport
 	hubClient     *http.Client
 	hubClientOnce sync.Once
 	hostInfoSent  bool
@@ -68,9 +67,6 @@ func New(cfg *Config, cfgPath, version string) *Frontman {
 	}
 
 	fm.configureLogger()
-
-	fm.initHTTPTransport()
-
 	return fm
 }
 

--- a/types.go
+++ b/types.go
@@ -46,7 +46,7 @@ type WebCheckData struct {
 	SearchHTMLSource    bool              `json:"searchHtmlSource"`
 	ExpectedPattern     string            `json:"expectedPattern,omitempty"`
 	DontFollowRedirects bool              `json:"dontFollowRedirects"`
-	IgnoreSSLErrors     bool              `json:"ignoreSSLErrors,omitempty"`
+	IgnoreSSLErrors     *bool             `json:"ignoreSSLErrors,omitempty"`
 	Timeout             float64           `json:"timeout,omitempty"`
 	Headers             map[string]string `json:"headers,omitempty"`
 }

--- a/webcheck.go
+++ b/webcheck.go
@@ -53,8 +53,8 @@ loopDom:
 	return
 }
 
-func (fm *Frontman) initHTTPTransport() {
-	fm.httpTransport = &http.Transport{
+func (fm *Frontman) newHTTPTransport(ignoreSSLErrors bool) *http.Transport {
+	t := &http.Transport{
 		DisableKeepAlives: true,
 		Proxy:             http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
@@ -65,17 +65,15 @@ func (fm *Frontman) initHTTPTransport() {
 		MaxIdleConns:          1,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
-		TLSClientConfig:       fm.newTLSClientConfig(fm.Config.IgnoreSSLErrors),
+		TLSClientConfig:       &tls.Config{},
 	}
-}
 
-func (fm *Frontman) newTLSClientConfig(insecure bool) *tls.Config {
-	c := &tls.Config{}
-	if insecure {
-		c.InsecureSkipVerify = true
-		c.RootCAs = fm.rootCAs
+	if ignoreSSLErrors { // TODO: honor fm.Config.IgnoreSSLErrors value
+		t.TLSClientConfig.InsecureSkipVerify = true
+		t.TLSClientConfig.RootCAs = fm.rootCAs
 	}
-	return c
+
+	return t
 }
 
 func checkBodyReaderMatchesPattern(reader io.Reader, pattern string, extractTextFromHTML bool) error {
@@ -106,14 +104,12 @@ func (fm *Frontman) runWebCheck(data WebCheckData) (map[string]interface{}, erro
 	m := make(map[string]interface{})
 	m[prefix+"success"] = 0
 
-	var httpTransport = fm.httpTransport
-	httpTransport.TLSClientConfig = fm.newTLSClientConfig(data.IgnoreSSLErrors)
-
 	// In case the webcheck disables redirect following we set maxRedirects to 0
 	maxRedirects := 0
 	if !data.DontFollowRedirects {
 		maxRedirects = fm.Config.HTTPCheckMaxRedirects
 	}
+	var httpTransport = fm.newHTTPTransport(data.IgnoreSSLErrors)
 	httpClient := fm.newClientWithOptions(httpTransport, maxRedirects)
 
 	timeout := fm.Config.HTTPCheckTimeout

--- a/webcheck.go
+++ b/webcheck.go
@@ -53,7 +53,7 @@ loopDom:
 	return
 }
 
-func (fm *Frontman) newHTTPTransport(ignoreSSLErrors bool) *http.Transport {
+func (fm *Frontman) newHTTPTransport(ignoreSSLErrors *bool) *http.Transport {
 	t := &http.Transport{
 		DisableKeepAlives: true,
 		Proxy:             http.ProxyFromEnvironment,
@@ -68,7 +68,9 @@ func (fm *Frontman) newHTTPTransport(ignoreSSLErrors bool) *http.Transport {
 		TLSClientConfig:       &tls.Config{},
 	}
 
-	if ignoreSSLErrors { // TODO: honor fm.Config.IgnoreSSLErrors value
+	valueProvided := ignoreSSLErrors != nil
+	if (valueProvided && *ignoreSSLErrors) ||
+		(!valueProvided && fm.Config.IgnoreSSLErrors) {
 		t.TLSClientConfig.InsecureSkipVerify = true
 		t.TLSClientConfig.RootCAs = fm.rootCAs
 	}


### PR DESCRIPTION
Fixes DEV-1452

For more reasons behind the changes you can take a look at the /usr/lib/go/src/net/http/transport.go persistConn.addTLS() implementation. It clones the tls config from previously persisted connection (from other webcheck) which results in incorrect comparison of host names.

Also it turned out that frontman' config field "IgnoreSSLErrors" has always been rewritten by webcheck config value "IgnoreSSLErrors". The implementation was fixed to honor config field. Web-check config ignoreSSLErrors json field still has precedence over global config value, but only if it was explicitly specified.