### PR TITLE
Switch off circleci docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,7 @@ jobs:
     <<: *docker_job
     steps:
       - <<: *workspace
+      - setup_remote_docker
       - run:
           name: Install Docker client
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,8 +47,6 @@ jobs:
     <<: *docker_job
     steps:
       - <<: *workspace
-      - setup_remote_docker:
-          docker_layer_caching: true
       - run:
           name: Install Docker client
           command: |


### PR DESCRIPTION
The docker layer caching is no more available in Circle CI free plan