### PR TITLE
Rework SSL checks implementation to fix issues and catch more invalid certificates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     <<: *docker_job
     steps:
       - <<: *workspace
-      - run: make test
+      - run: make test-short
 
   test-goreleaser:
     <<: *docker_job

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ build:
 test:
 	$(GOTEST) -v ./...
 
+test-short:
+	$(GOTEST) -short -v ./...
+
 clean:
 	$(GOCLEAN)
 	rm -f $(BINARY_NAME)

--- a/ssl.go
+++ b/ssl.go
@@ -61,39 +61,73 @@ func (fm *Frontman) runSSLCheck(addr *net.TCPAddr, hostname, service string) (m 
 	defer connection.Close()
 
 	m[prefix+"expiryDaysRemaining"] = math.MaxFloat64
-	for _, cert := range connection.ConnectionState().PeerCertificates {
-		remainingValidity := time.Until(cert.NotAfter).Hours() / 24
+	certs := connection.ConnectionState().PeerCertificates
 
-		if remainingValidity < m[prefix+"expiryDaysRemaining"].(float64) {
-			m[prefix+"expiryDaysRemaining"] = remainingValidity
+	for i, cert := range certs {
+		opts := x509.VerifyOptions{
+			Intermediates: x509.NewCertPool(),
 		}
-
-		if remainingValidity <= 0 {
-			err = fmt.Errorf("certificate is expired: %s", certName(cert))
-			return
-		} else if remainingValidity <= float64(fm.Config.SSLCertExpiryThreshold) {
-			err = fmt.Errorf("certificate will expire soon: %s", certName(cert))
-			return
-		}
-
-		if cert.NotBefore.After(time.Now()) {
-			err = fmt.Errorf("certificate is not valid yet: %s", certName(cert))
-			return
-		}
-
 		if !cert.IsCA && hostname != "" {
-			err = cert.VerifyHostname(hostname)
-			if err != nil {
-				logrus.Debugf("serviceCheck: SSL check for '%s' failed: %s", hostname, err.Error())
-				err = errors.New(strings.TrimPrefix(err.Error(), "x509: certificate"))
+			opts.DNSName = hostname
+		}
+
+		if i == 0 {
+			for j, cert := range certs {
+				if j != 0 {
+					opts.Intermediates.AddCert(cert)
+				}
 			}
 		}
 
+		var chains [][]*x509.Certificate
+		chains, err = cert.Verify(opts)
+		if err != nil {
+			logrus.Debugf("serviceCheck: SSL check for '%s' failed: %s", hostname, err.Error())
+			err = errors.New(strings.TrimPrefix(err.Error(), "x509: "))
+			return
+		}
+
+		if i == 0 {
+			remainingValidity, firstCertToExpire := findCertRemainingValidity(chains)
+			m[prefix+"expiryDaysRemaining"] = remainingValidity
+
+			if remainingValidity <= float64(fm.Config.SSLCertExpiryThreshold) {
+				err = fmt.Errorf("certificate will expire soon: %s", certName(firstCertToExpire))
+				return
+			}
+		}
 	}
 
-	if err == nil {
-		m[prefix+"success"] = 1
-	}
-
+	m[prefix+"success"] = 1
 	return
+}
+
+func findCertRemainingValidity(certChains [][]*x509.Certificate) (float64, *x509.Certificate) {
+	var remainingValidity float64
+	var firstToExpire *x509.Certificate
+
+	// find chain with max remaining validity
+	for _, chain := range certChains {
+		chainRemainingValidity, c := findChainRemainingValidity(chain)
+		if chainRemainingValidity > remainingValidity {
+			remainingValidity = chainRemainingValidity
+			firstToExpire = c
+		}
+	}
+	return remainingValidity, firstToExpire
+}
+
+func findChainRemainingValidity(chain []*x509.Certificate) (float64, *x509.Certificate) {
+	var min = math.MaxFloat64
+	var firstToExpire *x509.Certificate
+
+	// find cert that will expire first
+	for _, cert := range chain {
+		remainingValidity := time.Until(cert.NotAfter).Hours() / 24
+		if remainingValidity < min {
+			min = remainingValidity
+			firstToExpire = cert
+		}
+	}
+	return min, firstToExpire
 }

--- a/ssl.go
+++ b/ssl.go
@@ -72,11 +72,7 @@ func (fm *Frontman) runSSLCheck(addr *net.TCPAddr, hostname, service string) (m 
 		}
 
 		if i == 0 {
-			for j, cert := range certs {
-				if j != 0 {
-					opts.Intermediates.AddCert(cert)
-				}
-			}
+			addCertificatesToPool(opts.Intermediates, certs[1:])
 		}
 
 		var chains [][]*x509.Certificate
@@ -100,6 +96,12 @@ func (fm *Frontman) runSSLCheck(addr *net.TCPAddr, hostname, service string) (m 
 
 	m[prefix+"success"] = 1
 	return
+}
+
+func addCertificatesToPool(pool *x509.CertPool, certs []*x509.Certificate) {
+	for _, cert := range certs {
+		pool.AddCert(cert)
+	}
 }
 
 func findCertRemainingValidity(certChains [][]*x509.Certificate) (float64, *x509.Certificate) {

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -1,0 +1,102 @@
+// +build !quick_tests
+
+package frontman
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFrontman_runSSLCheck(t *testing.T) {
+	badSSL := []string{
+		"expired.badssl.com",
+		"wrong.host.badssl.com",
+		"self-signed.badssl.com",
+		"untrusted-root.badssl.com",
+
+		"sha1-intermediate.badssl.com",
+
+		// cipher suite
+		"rc4-md5.badssl.com",
+		"rc4.badssl.com",
+		"null.badssl.com",
+
+		// key exchange
+		"dh480.badssl.com",
+		"dh512.badssl.com",
+		"dh1024.badssl.com",
+		"dh2048.badssl.com",
+		"dh-small-subgroup.badssl.com",
+		"dh-composite.badssl.com",
+
+		// certificate transparency
+		"invalid-expected-sct.badssl.com",
+
+		// upgrade
+		"subdomain.preloaded-hsts.badssl.com",
+
+		// known bad
+		"Superfish.badssl.com",
+		"eDellRoot.badssl.com",
+		"DSDTestProvider.badssl.com",
+		"preact-cli.badssl.com",
+		"webpack-dev-server.badssl.com",
+
+		// chrome tests
+		"captive-portal.badssl.com",
+		"mitm-software.badssl.com",
+
+		// defunct
+		"sha1-2017.badssl.com",
+	}
+
+	goodSSL := []string{
+		"badssl.com",
+		"sha256.badssl.com",
+		"sha384.badssl.com",
+		"sha512.badssl.com",
+
+		"1000-sans.badssl.com",
+		"ecc256.badssl.com",
+		"ecc384.badssl.com",
+		"rsa2048.badssl.com",
+		"rsa4096.badssl.com",
+		"extended-validation.badssl.com",
+		"client.badssl.com",
+		"mozilla-modern.badssl.com",
+
+		"hsts.badssl.com",
+		"upgrade.badssl.com",
+		"preloaded-hsts.badssl.com",
+		"https-everywhere.badssl.com",
+
+		"long-extended-subdomain-name-containing-many-letters-and-dashes.badssl.com",
+		"longextendedsubdomainnamewithoutdashesinordertotestwordwrapping.badssl.com",
+	}
+
+	if testing.Short() {
+		badSSL = badSSL[:2]
+		goodSSL = goodSSL[:2]
+	}
+
+	cfg, _ := HandleAllConfigSetup(DefaultCfgPath)
+	fm := helperCreateFrontman(t, cfg)
+
+	for _, badSSLHost := range badSSL {
+		ipaddr, resolveErr := resolveIPAddrWithTimeout(badSSLHost, timeoutDNSResolve * 10)
+		assert.NoError(t, resolveErr)
+
+		_, err := fm.runSSLCheck(&net.TCPAddr{IP: ipaddr.IP, Port: 443}, badSSLHost, "https")
+		assert.Error(t, err, badSSLHost)
+	}
+
+	for _, goodSSLHost := range goodSSL {
+		ipaddr, resolveErr := resolveIPAddrWithTimeout(goodSSLHost, timeoutDNSResolve * 10)
+		assert.NoError(t, resolveErr)
+
+		_, err := fm.runSSLCheck(&net.TCPAddr{IP: ipaddr.IP, Port: 443}, goodSSLHost, "https")
+		assert.NoError(t, err, goodSSLHost)
+	}
+}


### PR DESCRIPTION
Old implementation wasn't checking for CA certificates validity. Also it didn't support certificates with multiple chains supplied.
New tests added to check for bad and good certificates.

Fixes DEV-1506