### PR TITLE
Fix building releases when multiple tags pointing to the same commit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 docker_job_setup: &docker_job
   docker:
-    - image: cloudradario/go-build:0.0.17
+    - image: cloudradario/go-build:0.0.18
   working_directory: /go/src/github.com/cloudradar-monitoring/frontman
 
 attach_workspace: &workspace
@@ -49,6 +49,7 @@ jobs:
         type: string
     environment:
       RELEASE_MODE: << parameters.release_mode >>
+      GORELEASER_CURRENT_TAG: ${CIRCLE_TAG}
     steps:
       - <<: *workspace
       - run:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,20 +38,21 @@ builds:
     goarch: mipsle
   ldflags:
     - "-s -w  -X {{.Env.PROJECT}}.Version={{.Version}} -X \"{{.Env.PROJECT}}.SelfUpdatesFeedURL={{.Env.SELF_UPDATES_FEED_URL}}\""
-archive:
-  files:
-  - README.md
-  - example.json
-  - example.config.toml
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  -
+    files:
+    - README.md
+    - example.json
+    - example.config.toml
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+      - goos: windows
+        format: zip
 checksum:
   name_template: 'checksums.txt'
 snapshot:
@@ -62,53 +63,54 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-nfpm:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+nfpms:
+  -
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
 
-  vendor: cloudradar GmbH
-  maintainer: CloudRadar GmbH <frontman@cloudradar.io>
-  homepage: https://cloudradar.io
-  description: Monitoring proxy for agentless monitoring of subnets
-  license: MIT
+    vendor: cloudradar GmbH
+    maintainer: CloudRadar GmbH <frontman@cloudradar.io>
+    homepage: https://cloudradar.io
+    description: Monitoring proxy for agentless monitoring of subnets
+    license: MIT
 
-  # Formats to be generated.
-  formats:
-  - deb
-  - rpm
+    # Formats to be generated.
+    formats:
+    - deb
+    - rpm
 
-  recommends:
-  - ca-certificates
-  - procps
+    recommends:
+    - ca-certificates
+    - procps
 
-  # Override default /usr/local/bin destination for binaries
-  bindir: /usr/bin
+    # Override default /usr/local/bin destination for binaries
+    bindir: /usr/bin
 
-  # Empty folders that should be created and managed by the packager
-  # implementation.
-  empty_folders:
-  - /var/log/frontman
-  - /etc/frontman
-  - /usr/share/frontman
+    # Empty folders that should be created and managed by the packager
+    # implementation.
+    empty_folders:
+    - /var/log/frontman
+    - /etc/frontman
+    - /usr/share/frontman
 
-  # Put example.json
-  files:
-    "example.json": "/usr/share/doc/frontman/example.json"
-    "example.config.toml": "/etc/frontman/example.config.toml"
-    "cacert.pem": "/etc/frontman/cacert.pem"
+    # Put example.json
+    files:
+      "example.json": "/usr/share/doc/frontman/example.json"
+      "example.config.toml": "/etc/frontman/example.config.toml"
+      "cacert.pem": "/etc/frontman/cacert.pem"
 
-  scripts:
-    preinstall: "pkg-scripts/preinstall.sh"
-    postinstall: "pkg-scripts/postinstall.sh"
-    preremove: "pkg-scripts/preremove.sh"
+    scripts:
+      preinstall: "pkg-scripts/preinstall.sh"
+      postinstall: "pkg-scripts/postinstall.sh"
+      preremove: "pkg-scripts/preremove.sh"
 
-  overrides:
-    rpm:
-      recommends:
-      - ca-certificates
-      - procps-ng
-      scripts:
-        postinstall: "pkg-scripts/postinstall-rpm.sh"
-        preremove: "pkg-scripts/preremove-rpm.sh"
+    overrides:
+      rpm:
+        recommends:
+        - ca-certificates
+        - procps-ng
+        scripts:
+          postinstall: "pkg-scripts/postinstall-rpm.sh"
+          preremove: "pkg-scripts/preremove-rpm.sh"
 
 release:
   github:


### PR DESCRIPTION
goreleaser uses "git describe" command to get release name. It always returns same tag even if there are multiple tags pointing to same commit.
Starting from v0.126 goreleaser supports overriding tag name using env variable: goreleaser/goreleaser#1327