### PR TITLE
fix ICMP problems on CentOS (DEV-1523)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,6 +97,7 @@ nfpms:
       "example.json": "/usr/share/doc/frontman/example.json"
       "example.config.toml": "/etc/frontman/example.config.toml"
       "cacert.pem": "/etc/frontman/cacert.pem"
+      "pkg-scripts/frontman.tt": "/etc/frontman/frontman.tt"
 
     scripts:
       preinstall: "pkg-scripts/preinstall.sh"

--- a/pkg-scripts/frontman.tt
+++ b/pkg-scripts/frontman.tt
@@ -1,0 +1,20 @@
+# SELinux policy for frontman
+
+module frontman 1.0;
+
+require {
+	type rpm_script_t;
+	type node_t;
+	type unconfined_service_t;
+	type unconfined_t;
+	class icmp_socket node_bind;
+}
+
+#============= rpm_script_t ==============
+allow rpm_script_t node_t:icmp_socket node_bind;
+
+#============= unconfined_service_t ==============
+allow unconfined_service_t node_t:icmp_socket node_bind;
+
+#============= unconfined_t ==============
+allow unconfined_t node_t:icmp_socket node_bind;

--- a/pkg-scripts/postinstall-rpm.sh
+++ b/pkg-scripts/postinstall-rpm.sh
@@ -6,6 +6,15 @@ CONFIG_PATH=/etc/frontman/frontman.conf
 # Upgrade: 2 or higher (depending on the number of versions installed)
 versionsCount=$1
 
+# install selinux policy if SELinux is installed
+sestatus
+if [ $? -eq 0 ]; then
+    echo "Installing SELinux policy for frontman"
+    checkmodule -M -m -o frontman.mod /etc/frontman/frontman.tt
+    semodule_package -o frontman.pp -m frontman.mod
+    semodule -i frontman.pp
+fi
+
 if [ ${versionsCount} = 1 ]; then # fresh install
     /usr/bin/frontman -y -s frontman -c ${CONFIG_PATH}
 else # package update

--- a/pkg-scripts/preinstall.sh
+++ b/pkg-scripts/preinstall.sh
@@ -10,6 +10,6 @@ if [ -z `getent passwd frontman` ]; then
   useradd  --gid frontman --system --shell /bin/false frontman
 fi
 
-mkdir -p /usr/lib/sysctl.d
+mkdir -p /etc/sysctl.d
 sysctl -w net.ipv4.ping_group_range="0   2147483647"
-echo "net.ipv4.ping_group_range = 0 2147483647" > /usr/lib/sysctl.d/50-ping_group_range.conf
+echo "net.ipv4.ping_group_range = 0 2147483647" > /etc/sysctl.d/50-ping_group_range.conf


### PR DESCRIPTION
CentOS 6 - adjust sysctl path to one that is respected by the system
CentOS 7 worked before
CentOS 8 - add selinux policy to allow icmp ping