### PR TITLE
ssl: fix connection to a dual-stack host where only IPv4 is working

### DIFF
--- a/servicecheck.go
+++ b/servicecheck.go
@@ -48,7 +48,7 @@ func (fm *Frontman) runServiceCheck(check ServiceCheck) (map[string]interface{},
 		case ProtocolSSL:
 			port, _ := check.Check.Port.Int64()
 
-			results, err = fm.runSSLCheck(&net.TCPAddr{IP: ipaddr.IP, Port: int(port)}, check.Check.Connect, check.Check.Service)
+			results, err = fm.runSSLCheck(check.Check.Connect, int(port), check.Check.Service)
 			if err != nil {
 				logrus.Debugf("serviceCheck: %s: %s", check.UUID, err.Error())
 			}

--- a/ssl.go
+++ b/ssl.go
@@ -116,7 +116,6 @@ func findCertRemainingValidity(certChains [][]*x509.Certificate) (float64, *x509
 
 	// find chain with max remaining validity
 	for _, chain := range certChains {
-		// fmt.Printf("checking chain of len %d", len(chain))
 		chainRemainingValidity, c := findChainRemainingValidity(chain)
 		if chainRemainingValidity > remainingValidity {
 			remainingValidity = chainRemainingValidity

--- a/ssl_test.go
+++ b/ssl_test.go
@@ -3,7 +3,6 @@
 package frontman
 
 import (
-	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -85,18 +84,18 @@ func TestFrontman_runSSLCheck(t *testing.T) {
 	fm := helperCreateFrontman(t, cfg)
 
 	for _, badSSLHost := range badSSL {
-		ipaddr, resolveErr := resolveIPAddrWithTimeout(badSSLHost, timeoutDNSResolve * 10)
+		_, resolveErr := resolveIPAddrWithTimeout(badSSLHost, timeoutDNSResolve*10)
 		assert.NoError(t, resolveErr)
 
-		_, err := fm.runSSLCheck(&net.TCPAddr{IP: ipaddr.IP, Port: 443}, badSSLHost, "https")
+		_, err := fm.runSSLCheck(badSSLHost, 443, "https")
 		assert.Error(t, err, badSSLHost)
 	}
 
 	for _, goodSSLHost := range goodSSL {
-		ipaddr, resolveErr := resolveIPAddrWithTimeout(goodSSLHost, timeoutDNSResolve * 10)
+		_, resolveErr := resolveIPAddrWithTimeout(goodSSLHost, timeoutDNSResolve*10)
 		assert.NoError(t, resolveErr)
 
-		_, err := fm.runSSLCheck(&net.TCPAddr{IP: ipaddr.IP, Port: 443}, goodSSLHost, "https")
+		_, err := fm.runSSLCheck(goodSSLHost, 443, "https")
 		assert.NoError(t, err, goodSSLHost)
 	}
 }


### PR DESCRIPTION
Fixes DEV-1549 by letting tls.DialWithDialer() handle IP resolution and fallback