### PR TITLE
additional rework of frontman for proper threading

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     <<: *docker_job
     steps:
       - <<: *workspace
-      - run: make test-short
+      - run: go test -v -short -race ./...
 
   test-goreleaser:
     <<: *docker_job

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 
 docker_job_setup: &docker_job
   docker:
-    - image: cloudradario/go-build:0.0.18
+    - image: cloudradario/go-build:0.0.19
   working_directory: /go/src/github.com/cloudradar-monitoring/frontman
 
 attach_workspace: &workspace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,162 @@
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 1m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+output:
+  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+# all available settings of specific linters
+linters-settings:
+  errcheck:
+    # report about not checking of errors in type assetions: `a := b.(MyStruct)`;
+    # default is false: such cases aren't reported by default.
+    check-type-assertions: false
+
+    # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
+    # default is false: such cases aren't reported by default.
+    check-blank: false
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+  golint:
+    # minimal confidence for issues, default is 0.8
+    min-confidence: 0.8
+  gofmt:
+    # simplify code: gofmt with `-s` option, true by default
+    simplify: true
+  goimports:
+    # put imports beginning with prefix after 3rd-party packages;
+    # it's a comma-separated list of prefixes
+    local-prefixes: github.com/cloudradar-monitoring/cagent
+  gocyclo:
+    # minimal code complexity to report, 30 by default (but we recommend 10-20)
+    min-complexity: 25
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 100
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+  depguard:
+    list-type: blacklist
+    include-go-root: false
+    packages:
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+    ignore-words:
+      - utilisation # can't be fixed due to back compatibility issues.
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 120
+    # tab width in spaces. Default to 1.
+    tab-width: 1
+  unused:
+    # treat code as a program (not a library) and report unused exported identifiers; default is false.
+    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+  unparam:
+    # call graph construction algorithm (cha, rta). In general, use cha for libraries,
+    # and rta for programs with main packages. Default is cha.
+    algo: cha
+
+    # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
+    # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
+    # if it's called for subdir of a project it can't find external interfaces. All text editor integrations
+    # with golangci-lint call it on a directory with the changed file.
+    check-exported: false
+  nakedret:
+    # make an issue if func has more lines of code than this setting and it has naked returns; default is 30
+    max-func-lines: 30
+  prealloc:
+    # XXX: we don't recommend using this linter before doing performance profiling.
+    # For most programs usage of prealloc will be a premature optimization.
+
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them.
+    # True by default.
+    simple: true
+    range-loops: true # Report preallocation suggestions on range loops, true by default
+    for-loops: false # Report preallocation suggestions on for loops, false by default
+
+
+linters:
+  enable:
+    - goimports
+    - golint
+    - gosimple
+    - structcheck
+    - deadcode
+    - staticcheck
+    - errcheck
+    - unused
+    - gosec
+    - dupl
+    - gocyclo
+    - misspell
+    - unparam
+  enable-all: false
+  disable:
+  disable-all: true
+  presets:
+  fast: false
+
+# issues:
+#   # List of regexps of issue texts to exclude, empty list by default.
+#   # But independently from this option we use default exclude patterns,
+#   # it can be disabled by `exclude-use-default: false`. To list all
+#   # excluded by default patterns execute `golangci-lint run --help`
+#   exclude:
+#     - abcdef
+
+#   # Independently from option `exclude` we use default exclude patterns,
+#   # it can be disabled by this option. To list all
+#   # excluded by default patterns execute `golangci-lint run --help`.
+#   # Default value for this option is true.
+#   exclude-use-default: false
+
+#   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+#   max-per-linter: 0
+
+#   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+#   max-same-issues: 0
+
+#   # Show only new issues: if there are unstaged changes or untracked files,
+#   # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+#   # It's a super-useful option for integration of golangci-lint into existing
+#   # large codebase. It's not practical to fix all existing issues at the moment
+#   # of integration: much better don't allow issues in new code.
+#   # Default is false.
+#   new: false
+
+new: true
+#   # Show only new issues created after git revision `REV`
+#   new-from-rev: REV
+
+#   # Show only new issues created in git patch with set file path.
+#   new-from-patch: path/to/patch/file

--- a/check.go
+++ b/check.go
@@ -18,7 +18,7 @@ type Check interface {
 type Input struct {
 	ServiceChecks []ServiceCheck `json:"serviceChecks"`
 	WebChecks     []WebCheck     `json:"webChecks"`
-	SNMPChecks    []SNMPCheck    `json:"snmpChecks"`
+	SNMPChecks    []SNMPCheck    `json:"snmpChecks,omitempty"`
 }
 
 type ServiceCheck struct {

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -178,7 +178,7 @@ func main() {
 	select {
 	case sig := <-sigc:
 		log.Infof("Got %s signal. Finishing the batch and exit...", sig.String())
-		interruptChan <- struct{}{}
+		close(interruptChan)
 		fm.TerminateQueue.Wait()
 		os.Exit(0)
 	case <-doneChan:

--- a/cmd/frontman/main.go
+++ b/cmd/frontman/main.go
@@ -168,10 +168,10 @@ func main() {
 		syscall.SIGHUP,
 		syscall.SIGINT,
 		syscall.SIGTERM)
-	doneChan := make(chan struct{})
+	doneChan := make(chan bool)
 	go func() {
 		fm.Run(*inputFilePtr, output, interruptChan, resultsChan)
-		doneChan <- struct{}{}
+		doneChan <- true
 	}()
 
 	//  Handle interrupts
@@ -643,7 +643,7 @@ func (sw *serviceWrapper) Start(s service.Service) error {
 }
 
 func (sw *serviceWrapper) Stop(s service.Service) error {
-	sw.InterruptChan <- struct{}{}
+	close(sw.InterruptChan)
 	log.Println("Finishing the batch and stop the service...")
 	<-sw.DoneChan
 	return nil

--- a/cmd/mockhub/main.go
+++ b/cmd/mockhub/main.go
@@ -11,7 +11,6 @@ func main() {
 
 	rand.Seed(time.Now().UnixNano())
 
-	hub := frontman.NewMockHub()
-
+	hub := frontman.NewMockHub("localhost:9100")
 	hub.Serve()
 }

--- a/cmd/mockhub/main.go
+++ b/cmd/mockhub/main.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"math/rand"
+	"time"
+
+	"github.com/cloudradar-monitoring/frontman"
+)
+
+func main() {
+
+	rand.Seed(time.Now().UnixNano())
+
+	hub := frontman.NewMockHub()
+
+	hub.Serve()
+}

--- a/config.go
+++ b/config.go
@@ -80,7 +80,7 @@ type Config struct {
 
 	SenderBatchSize int `toml:"sender_batch_size" comment:"Do not send back more than N results per POST request"`
 
-	SenderInterval int `toml:"sender_interval" comment:"Make a pause of N seconds between POST requests when processing the result queue"`
+	SenderInterval float64 `toml:"sender_interval" comment:"Make a pause of N seconds between POST requests when processing the result queue"`
 
 	HealthChecks HealthCheckConfig `toml:"health_checks" comment:"Frontman can verify a reliable internet uplink by pinging some reference hosts before each check round starts.\nPing all hosts of the list.\nOnly if frontman gets a positive answer form all of them, frontman continues.\nOtherwise, the entire check round is skipped. No data is sent back.\nFailed health checks are recorded to the log.\nOnly 0% packet loss is considered as a positive check result. Pings are performed in parallel.\nDisabled by default. Enable by declaring reference_ping_hosts targets\n"`
 

--- a/frontman.go
+++ b/frontman.go
@@ -47,13 +47,11 @@ type Frontman struct {
 	failedNodeCache map[string]Node
 
 	// current checks queue
-	checks []Check
+	checks           []Check
+	updateChecksLock sync.Mutex
 
 	// in-progress checks
 	ipc inProgressChecks
-
-	// used to keep hub fetch of new checks in sync
-	updateChecksLock sync.Mutex
 
 	previousSNMPBandwidthMeasure  []snmpBandwidthMeasure
 	previousSNMPOidDeltaMeasure   []snmpOidDeltaMeasure

--- a/frontman.go
+++ b/frontman.go
@@ -29,7 +29,9 @@ type Frontman struct {
 	Config         *Config
 	ConfigLocation string
 
-	Stats                       *stats.FrontmanStats
+	stats     *stats.FrontmanStats
+	statsLock sync.Mutex
+
 	HealthCheckPassedPreviously bool
 
 	selfUpdater *selfupdate.Updater
@@ -69,7 +71,7 @@ func New(cfg *Config, cfgPath, version string) (*Frontman, error) {
 	fm := &Frontman{
 		Config:                      cfg,
 		ConfigLocation:              cfgPath,
-		Stats:                       &stats.FrontmanStats{},
+		stats:                       &stats.FrontmanStats{},
 		HealthCheckPassedPreviously: true,
 		hostInfoSent:                false,
 		version:                     version,

--- a/frontman.go
+++ b/frontman.go
@@ -63,6 +63,9 @@ type Frontman struct {
 }
 
 func New(cfg *Config, cfgPath, version string) (*Frontman, error) {
+	if version == "" {
+		version = "{undefined}"
+	}
 	fm := &Frontman{
 		Config:                      cfg,
 		ConfigLocation:              cfgPath,
@@ -127,11 +130,8 @@ func (fm *Frontman) configureAutomaticSelfUpdates() error {
 	return nil
 }
 
+// returns an user agent string
 func (fm *Frontman) userAgent() string {
-	if fm.version == "" {
-		fm.version = "{undefined}"
-	}
 	parts := strings.Split(fm.version, "-")
-
 	return fmt.Sprintf("Frontman v%s %s %s", parts[0], runtime.GOOS, runtime.GOARCH)
 }

--- a/frontman.go
+++ b/frontman.go
@@ -38,7 +38,9 @@ type Frontman struct {
 	hubClientOnce sync.Once
 	hostInfoSent  bool
 
+	// local cached results in case the hub is temporarily offline
 	offlineResultsBuffer []Result
+	offlineResultsLock   sync.Mutex
 
 	rootCAs *x509.CertPool
 	version string

--- a/frontman.go
+++ b/frontman.go
@@ -51,8 +51,8 @@ type Frontman struct {
 	failedNodeCache map[string]Node
 
 	// current checks queue
-	checks           []Check
-	updateChecksLock sync.Mutex
+	checks     []Check
+	checksLock sync.Mutex
 
 	// in-progress checks
 	ipc inProgressChecks

--- a/frontman.go
+++ b/frontman.go
@@ -105,16 +105,16 @@ func New(cfg *Config, cfgPath, version string) (*Frontman, error) {
 	return fm, nil
 }
 
-func (ca *Frontman) configureAutomaticSelfUpdates() error {
-	if !ca.Config.Updates.Enabled {
+func (fm *Frontman) configureAutomaticSelfUpdates() error {
+	if !fm.Config.Updates.Enabled {
 		return nil
 	}
 	updatesConfig := selfupdate.DefaultConfig()
 	updatesConfig.AppName = "frontman"
 	updatesConfig.SigningCertificatedName = "cloudradar GmbH"
 	updatesConfig.CurrentVersion = Version
-	updatesConfig.CheckInterval = ca.Config.Updates.GetCheckInterval()
-	updatesConfig.UpdatesFeedURL = ca.Config.Updates.URL
+	updatesConfig.CheckInterval = fm.Config.Updates.GetCheckInterval()
+	updatesConfig.UpdatesFeedURL = fm.Config.Updates.URL
 	logrus.Debugf("using %s as self-updates feed URL", updatesConfig.UpdatesFeedURL)
 
 	err := selfupdate.Configure(updatesConfig)

--- a/frontman_test.go
+++ b/frontman_test.go
@@ -13,12 +13,20 @@ func helperCreateFrontman(t *testing.T, cfg *Config) *Frontman {
 	return fm
 }
 
-// XXX end-2-end test
-
 func TestFrontmanHubInput(t *testing.T) {
-	// XXX 1. mock hub. fetch checks
+	hub := NewMockHub("localhost:9100")
+	go hub.Serve()
 
-	hub := NewMockHub()
-	go hub.Serve() // XXX no way to close cleanly
+	cfg, err := HandleAllConfigSetup(DefaultCfgPath)
+	assert.Nil(t, err)
 
+	cfg.HubURL = hub.URL() + "/?serviceChecks=0&webChecks=2"
+
+	fm := helperCreateFrontman(t, cfg)
+
+	resultsChan := make(chan Result, 100)
+	interruptChan := make(chan struct{})
+
+	fm.Run("", nil, interruptChan, resultsChan)
+	// XXX stop after some time
 }

--- a/frontman_test.go
+++ b/frontman_test.go
@@ -2,6 +2,7 @@ package frontman
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -20,13 +21,25 @@ func TestFrontmanHubInput(t *testing.T) {
 	cfg, err := HandleAllConfigSetup(DefaultCfgPath)
 	assert.Nil(t, err)
 
-	cfg.HubURL = hub.URL() + "/?serviceChecks=0&webChecks=2"
+	cfg.HubURL = hub.URL() + "/?serviceChecks=10&webChecks=10"
+	cfg.LogLevel = "debug"
+	cfg.Sleep = 1           // delay between each round of checks
+	cfg.SenderBatchSize = 2 // number of results to send to hub at once
+	cfg.SenderInterval = 1
+	cfg.ICMPTimeout = 0.1
+	cfg.HTTPCheckTimeout = 1.0
 
 	fm := helperCreateFrontman(t, cfg)
 
 	resultsChan := make(chan Result, 100)
 	interruptChan := make(chan struct{})
 
-	fm.Run("", nil, interruptChan, resultsChan)
-	// XXX stop after some time
+	go fm.Run("", nil, interruptChan, resultsChan)
+
+	// stop after some time
+	time.Sleep(5 * time.Second)
+	close(interruptChan)
+	time.Sleep(1 * time.Second)
+
+	assert.Equal(t, true, fm.ipc.len() > 0)
 }

--- a/frontman_test.go
+++ b/frontman_test.go
@@ -12,3 +12,13 @@ func helperCreateFrontman(t *testing.T, cfg *Config) *Frontman {
 	assert.Nil(t, err)
 	return fm
 }
+
+// XXX end-2-end test
+
+func TestFrontmanHubInput(t *testing.T) {
+	// XXX 1. mock hub. fetch checks
+
+	hub := NewMockHub()
+	go hub.Serve() // XXX no way to close cleanly
+
+}

--- a/handler.go
+++ b/handler.go
@@ -463,6 +463,10 @@ func (fm *Frontman) processInputContinuous(inputFilePath string, local bool, int
 
 				res, _ := fm.runCheck(check, local)
 				inProgress.remove(check.uniqueID())
+				fm.statsLock.Lock()
+				fm.stats.ChecksPerformedTotal++
+				fm.statsLock.Unlock()
+
 				*results <- *res
 			}(currentCheck, resultsChan, &fm.ipc, &waitWg)
 		}

--- a/handler.go
+++ b/handler.go
@@ -84,7 +84,6 @@ func (fm *Frontman) initHubClient() {
 // * for TOML: CheckHubCredentials(ctx, "hub_url", "hub_user", "hub_password")
 // * for WinUI: CheckHubCredentials(ctx, "URL", "User", "Password")
 func (fm *Frontman) CheckHubCredentials(ctx context.Context, fieldHubURL, fieldHubUser, fieldHubPassword string) error {
-	fm.initHubClient()
 
 	if fm.Config.HubURL == "" {
 		return newEmptyFieldError(fieldHubURL)
@@ -142,8 +141,6 @@ func (fm *Frontman) checkClientError(resp *http.Response, err error, fieldHubUse
 }
 
 func (fm *Frontman) inputFromHub() (*Input, error) {
-	fm.initHubClient()
-
 	if fm.Config.HubURL == "" {
 		return nil, newEmptyFieldError("hub_url")
 	} else if u, err := url.Parse(fm.Config.HubURL); err != nil {
@@ -212,6 +209,7 @@ func (fm *Frontman) inputFromHub() (*Input, error) {
 // Run runs all checks continuously and sends result to hub or file
 func (fm *Frontman) Run(inputFilePath string, outputFile *os.File, interrupt chan struct{}, resultsChan chan Result) {
 
+	fm.initHubClient()
 	fm.Stats.StartedAt = time.Now()
 	logrus.Debugf("Start writing stats file: %s", fm.Config.StatsFile)
 	fm.StartWritingStats()
@@ -286,7 +284,7 @@ func (fm *Frontman) updateInputChecks(inputFilePath string) {
 
 // RunOnce runs all checks once and send result to hub or file
 func (fm *Frontman) RunOnce(inputFilePath string, outputFile *os.File, interrupt chan struct{}, resultsChan *chan Result) error {
-
+	fm.initHubClient()
 	fm.updateInputChecks(inputFilePath)
 	fm.processInput(fm.checks, true, resultsChan)
 

--- a/handler.go
+++ b/handler.go
@@ -276,8 +276,8 @@ func (fm *Frontman) Run(inputFilePath string, outputFile *os.File, interrupt cha
 
 // updates list of checks to execute from the hub
 func (fm *Frontman) updateInputChecks(inputFilePath string) {
-	fm.updateChecksLock.Lock()
-	defer fm.updateChecksLock.Unlock()
+	fm.checksLock.Lock()
+	defer fm.checksLock.Unlock()
 
 	checks, err := fm.fetchInputChecks(inputFilePath)
 	fm.handleHubError(err)
@@ -289,9 +289,9 @@ func (fm *Frontman) RunOnce(inputFilePath string, outputFile *os.File, interrupt
 	fm.initHubClient()
 	fm.updateInputChecks(inputFilePath)
 
-	fm.updateChecksLock.Lock()
+	fm.checksLock.Lock()
 	fm.processInput(fm.checks, true, resultsChan)
-	fm.updateChecksLock.Unlock()
+	fm.checksLock.Unlock()
 
 	logrus.Debugf("RunOnce")
 	close(*resultsChan)
@@ -412,8 +412,8 @@ func hasCheck(s []Check, uuid string) bool {
 
 // takes the oldest check from queue that is not in progress
 func (fm *Frontman) takeNextCheckNotInProgress() (Check, bool) {
-	fm.updateChecksLock.Lock()
-	defer fm.updateChecksLock.Unlock()
+	fm.checksLock.Lock()
+	defer fm.checksLock.Unlock()
 
 	if len(fm.checks) == 0 {
 		return nil, false

--- a/mockhub.go
+++ b/mockhub.go
@@ -13,10 +13,17 @@ import (
 )
 
 type MockHub struct {
+	address string
 }
 
-func NewMockHub() *MockHub {
-	return &MockHub{}
+func NewMockHub(address string) *MockHub {
+	return &MockHub{
+		address: address,
+	}
+}
+
+func (hub *MockHub) URL() string {
+	return "http://" + hub.address
 }
 
 // returns some mocked checks
@@ -35,7 +42,7 @@ func (hub *MockHub) postHandler(w http.ResponseWriter, r *http.Request) {
 		log.Fatal(err)
 	}
 
-	log.Println("post got data", data)
+	log.Println("MockHub: got post data", string(data))
 }
 
 func (hub *MockHub) getHandler(w http.ResponseWriter, r *http.Request) {
@@ -55,7 +62,7 @@ func (hub *MockHub) getHandler(w http.ResponseWriter, r *http.Request) {
 		webChecks = 5
 	}
 
-	log.Println("responding with", serviceChecks, "serviceChecks", webChecks, "webChecks")
+	log.Println("responding with", serviceChecks, "serviceChecks and", webChecks, "webChecks")
 
 	checks := Input{
 		ServiceChecks: mockServiceChecks(int(serviceChecks)),
@@ -68,12 +75,9 @@ func (hub *MockHub) getHandler(w http.ResponseWriter, r *http.Request) {
 
 func (hub *MockHub) Serve() {
 
-	var listenAddr = "localhost:9100"
-
 	http.HandleFunc("/", hub.indexHandler)
-
-	log.Println("mock hub listening at", "http://"+listenAddr)
-	http.ListenAndServe(listenAddr, nil)
+	log.Println("mock hub listening at", hub.URL())
+	http.ListenAndServe(hub.address, nil)
 }
 
 func mockServiceChecks(n int) []ServiceCheck {

--- a/mockhub.go
+++ b/mockhub.go
@@ -1,0 +1,201 @@
+package frontman
+
+// a mock hub used in tests, similar to https://bitbucket.org/cloudradar/debug_hub/
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"math/rand"
+	"net/http"
+	"strconv"
+)
+
+type MockHub struct {
+}
+
+func NewMockHub() *MockHub {
+	return &MockHub{}
+}
+
+// returns some mocked checks
+func (hub *MockHub) indexHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case "GET":
+		hub.getHandler(w, r)
+	case "POST":
+		hub.postHandler(w, r)
+	}
+}
+
+func (hub *MockHub) postHandler(w http.ResponseWriter, r *http.Request) {
+	data, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Println("post got data", data)
+}
+
+func (hub *MockHub) getHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	query := r.URL.Query()
+	serviceChecksS := query.Get("serviceChecks")
+	webChecksS := query.Get("webChecks")
+
+	serviceChecks, err := strconv.ParseInt(serviceChecksS, 10, 64)
+	if err != nil {
+		serviceChecks = 5
+	}
+
+	webChecks, err := strconv.ParseInt(webChecksS, 10, 64)
+	if err != nil {
+		webChecks = 5
+	}
+
+	log.Println("responding with", serviceChecks, "serviceChecks", webChecks, "webChecks")
+
+	checks := Input{
+		ServiceChecks: mockServiceChecks(int(serviceChecks)),
+		WebChecks:     mockWebChecks(int(webChecks)),
+	}
+
+	data, _ := json.Marshal(checks)
+	w.Write(data)
+}
+
+func (hub *MockHub) Serve() {
+
+	var listenAddr = "localhost:9100"
+
+	http.HandleFunc("/", hub.indexHandler)
+
+	log.Println("mock hub listening at", "http://"+listenAddr)
+	http.ListenAndServe(listenAddr, nil)
+}
+
+func mockServiceChecks(n int) []ServiceCheck {
+	res := []ServiceCheck{}
+	for i := 0; i < n; i++ {
+		res = append(res, randomServiceCheck())
+	}
+	return res
+}
+
+func mockWebChecks(n int) []WebCheck {
+	res := []WebCheck{}
+	for i := 0; i < n; i++ {
+		if i%5 == 0 {
+			// every fifth web check should be a lame web check
+			res = append(res, lameWebCheck())
+		} else {
+			res = append(res, randomWebCheck())
+		}
+	}
+	return res
+}
+
+func randomWebCheck() WebCheck {
+	methods := []string{"get", "post", "head"}
+	statuses := []int{200, 404}
+	patterns := []string{"running", "welcome", "yyy"}
+	return WebCheck{
+		UUID: randomUUID(),
+		Check: WebCheckData{
+			URL:                fmt.Sprintf("https://h%d.hostgum.eu/", rand.Intn(1000)),
+			Method:             methods[rand.Intn(len(methods))],
+			ExpectedHTTPStatus: statuses[rand.Intn(len(statuses))],
+			ExpectedPattern:    patterns[rand.Intn(len(patterns))],
+		},
+	}
+}
+
+func lameWebCheck() WebCheck {
+	return WebCheck{
+		UUID: randomUUID(),
+		Check: WebCheckData{
+			URL:                fmt.Sprintf("https://h1.hostgum.eu/sleep.php?t=%d", 5+rand.Intn(45)),
+			Method:             "get",
+			ExpectedHTTPStatus: 200,
+			ExpectedPattern:    "slept",
+			Timeout:            randomFloat(30, 60),
+		},
+	}
+}
+
+func randomFloat(min, max float64) float64 {
+	return min + rand.Float64()*(max-min)
+}
+
+func randomUUID() string {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		log.Fatal(err)
+	}
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}
+
+func randomServiceCheck() ServiceCheck {
+	switch rand.Intn(2) {
+	case 0:
+		return randomPingCheck()
+	default:
+		return randomTcpCheck()
+	}
+}
+
+func randomPingCheck() ServiceCheck {
+	return ServiceCheck{
+		UUID: randomUUID(),
+		Check: ServiceCheckData{
+			Connect:  randomConnect(),
+			Service:  "ping",
+			Protocol: "icmp",
+		},
+	}
+}
+
+func randomTcpCheck() ServiceCheck {
+	services := []string{
+		"http",
+		"https",
+		"pop3",
+		"imap",
+		"smtp",
+	}
+	return ServiceCheck{
+		UUID: randomUUID(),
+		Check: ServiceCheckData{
+			Connect:  fmt.Sprintf("h%d.hostgum.eu", rand.Intn(1000)),
+			Protocol: "tcp",
+			Service:  services[rand.Intn(len(services))],
+		},
+	}
+}
+
+func randomConnect() string {
+	pool := []string{
+		"www.google.com",
+		"8.8.8.8",
+		"8.8.4.4",
+		"1.1.1.1",
+		"h1.hostgum.eu",
+		"lameduck.hostgum.eu",
+		"not_exists_domain1234.com",
+		"github.com",
+		"dns.google",
+		"1.11.192.227",
+		"202.181.242.131",
+		"45.225.123.88",
+		"212.91.32.6",
+		"ns1.artechinfo.in",
+		"pb6abf7bd.szokff01.ap.so-net.ne.jp",
+		"211.105.7.5",
+		"dns.prhs.ptc.edu.tw",
+		"163.24.162.3",
+	}
+	return pool[rand.Intn(len(pool))]
+}

--- a/node.go
+++ b/node.go
@@ -115,7 +115,7 @@ func (fm *Frontman) askNodes(check Check, res *Result) {
 				body, _ := ioutil.ReadAll(resp.Body)
 				nodeResults = append(nodeResults, string(body))
 			} else {
-				logrus.Errorf("askNodes recieved HTTP %v from %s", resp.StatusCode, node.URL)
+				logrus.Errorf("askNodes received HTTP %v from %s", resp.StatusCode, node.URL)
 				fm.markNodeFailure(&node)
 			}
 		}
@@ -123,7 +123,7 @@ func (fm *Frontman) askNodes(check Check, res *Result) {
 
 	if len(nodeResults) == 0 {
 		// all nodes failed, use original measure
-		logrus.Errorf("askNodes recieved no successful results")
+		logrus.Errorf("askNodes received no successful results")
 		return
 	}
 

--- a/ping_ours.go
+++ b/ping_ours.go
@@ -33,13 +33,12 @@ func (fm *Frontman) runPing(addr string) (m map[string]interface{}, err error) {
 	m = make(map[string]interface{})
 
 	pinger, err := NewPinger(addr)
+	if err != nil {
+		return
+	}
 
 	if CheckIfRawICMPAvailable() || runtime.GOOS == "windows" {
 		pinger.SetPrivileged(true)
-	}
-
-	if err != nil {
-		return
 	}
 
 	pinger.Timeout = secToDuration(fm.Config.ICMPTimeout)

--- a/sendermode.go
+++ b/sendermode.go
@@ -108,9 +108,9 @@ func (fm *Frontman) postResultsToHub(results []Result) error {
 	fm.clearOfflineResultsBuffer()
 
 	// Update frontman statistics
-	fm.offlineResultsLock.Lock()
-	fm.Stats.BytesSentToHubTotal += uint64(bodyLength)
-	fm.offlineResultsLock.Unlock()
+	fm.statsLock.Lock()
+	fm.stats.BytesSentToHubTotal += uint64(bodyLength)
+	fm.statsLock.Unlock()
 
 	return nil
 }
@@ -139,7 +139,9 @@ func (fm *Frontman) sendResultsChanToHub(resultsChan *chan Result) error {
 		return fmt.Errorf("postResultsToHub: %s", err.Error())
 	}
 
-	fm.Stats.CheckResultsSentToHub += uint64(len(results))
+	fm.statsLock.Lock()
+	fm.stats.CheckResultsSentToHub += uint64(len(results))
+	fm.statsLock.Unlock()
 
 	fm.clearOfflineResultsBuffer()
 

--- a/sendermode.go
+++ b/sendermode.go
@@ -148,6 +148,7 @@ func (fm *Frontman) sendResultsChanToHubQueue(resultsChan *chan Result) error {
 	lastQueueStatsWrite := time.Unix(0, 0)
 
 	fm.TerminateQueue.Add(1)
+	defer fm.TerminateQueue.Done()
 
 	for {
 		select {
@@ -219,7 +220,6 @@ func (fm *Frontman) sendResultsChanToHubQueue(resultsChan *chan Result) error {
 		}
 
 		if shouldReturn && len(results) == 0 {
-			fm.TerminateQueue.Done()
 			return nil
 		}
 	}

--- a/sendermode.go
+++ b/sendermode.go
@@ -180,6 +180,11 @@ func (fm *Frontman) sendResultsChanToHubQueue(interrupt chan struct{}, resultsCh
 				lastSentToHub = time.Now()
 				go func(r []Result) {
 					err := fm.postResultsToHub(r)
+
+					fm.statsLock.Lock()
+					fm.stats.CheckResultsSentToHub += uint64(len(r))
+					fm.statsLock.Unlock()
+
 					if err != nil {
 						if err == ErrorHubGeneral {
 							// If the hub doesn't respond with 2XX, the results remain in the queue.

--- a/tcp.go
+++ b/tcp.go
@@ -50,7 +50,7 @@ func (fm *Frontman) runTCPCheck(hostname string, port int, service string) (Meas
 
 	prefix := fmt.Sprintf("net.tcp.%s.%d.", service, port)
 
-	// Initialise MeasurementsMap
+	// Initialize MeasurementsMap
 	m := MeasurementsMap{
 		prefix + "success": 0,
 	}

--- a/udp.go
+++ b/udp.go
@@ -27,7 +27,7 @@ func (fm *Frontman) runUDPCheck(hostname string, port int, service string) (Meas
 
 	prefix := fmt.Sprintf("net.udp.%s.%d.", service, port)
 
-	// Initialise MeasurementsMap
+	// Initialize MeasurementsMap
 	m := MeasurementsMap{
 		prefix + "success": 0,
 	}


### PR DESCRIPTION
Follow-up for DEV-1757

Fixes a crash noticed by Thorsten while testing
```
frontman -c /etc/frontman/frontman.conf
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xc0 pc=0x81e390]
goroutine 380 [running]:
github.com/cloudradar-monitoring/frontman.(*Pinger).SetPrivileged(...)
    /go/src/github.com/cloudradar-monitoring/frontman/ping.go:215
github.com/cloudradar-monitoring/frontman.(*Frontman).runPing(0xc00008d680, 0xc0003fccf0, 0xf, 0x0, 0x0, 0x0)
    /go/src/github.com/cloudradar-monitoring/frontman/ping_ours.go:38 +0x80
github.com/cloudradar-monitoring/frontman.ServiceCheck.run.func1(0xc0003bd500, 0x24, 0xc0003fccf0, 0xf, 0xc0003fcce8, 0x4, 0xc0003fccec, 0x4, 0xcf1c50, 0x1, ...)
    /go/src/github.com/cloudradar-monitoring/frontman/servicecheck.go:39 +0x79f
created by github.com/cloudradar-monitoring/frontman.ServiceCheck.run
    /go/src/github.com/cloudradar-monitoring/frontman/servicecheck.go:36 +0x222
```